### PR TITLE
Fixed bug linking number entities to the switch

### DIFF
--- a/custom_components/linktap/switch.py
+++ b/custom_components/linktap/switch.py
@@ -83,13 +83,13 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
     @property
     def duration_entity(self):
         name = self._name.replace(" ", "_")
-        name = self._name.replace("-", "_")
+        name = name.replace("-", "_")
         return f"number.{DOMAIN}_{name}_watering_duration".lower()
 
     @property
     def volume_entity(self):
         name = self._name.replace(" ", "_")
-        name = self._name.replace("-", "_")
+        name = name.replace("-", "_")
         return f"number.{DOMAIN}_{name}_watering_volume".lower()
 
     async def async_turn_on(self, **kwargs):


### PR DESCRIPTION
In fixing a previous issue with name matching, a different issue was created.
This change should fix both.