### PR TITLE
Added new service for valve to water for a defined period

### DIFF
--- a/custom_components/linktap/services.yaml
+++ b/custom_components/linktap/services.yaml
@@ -40,3 +40,16 @@ pause_valve:
     entity:
       integration: linktap
       domain: valve
+
+start_watering:
+  name: Pause
+  description: Turn on a valve for a set time
+  fields:
+    minutes:
+      name: Minutes
+      example: 1439
+      description: Duration in minutes
+  target:
+    entity:
+      integration: linktap
+      domain: valve

--- a/custom_components/linktap/valve.py
+++ b/custom_components/linktap/valve.py
@@ -44,6 +44,10 @@ async def async_setup_entry(
         {vol.Required("hours", default=1): vol.Coerce(int)},
         "_pause_tap"
         )
+    platform.async_register_entity_service("start_watering",
+        {vol.Required("minutes", default=1439): vol.Coerce(int)},
+        "_start_watering"
+        )
 
 class LinktapValve(CoordinatorEntity, ValveEntity):
     def __init__(self, coordinator: DataUpdateCoordinator, hass, tap):
@@ -146,3 +150,11 @@ class LinktapValve(CoordinatorEntity, ValveEntity):
         _LOGGER.debug(f"Pausing {self.entity_id} for {hours} hours")
         await self.tap_api.pause_tap(self._gw_id, self.tap_id, hours)
         await self.coordinator.async_request_refresh()
+
+    async def _start_watering(self, minutes=False):
+        if not minutes:
+            minutes = 1439
+        _LOGGER.debug(f"Starting watering for {minutes} minutes")
+        await self.tap_api.turn_on(self._gw_id, self.tap_id, minutes)
+        await self.coordinator.async_request_refresh()
+

--- a/custom_components/linktap/valve.py
+++ b/custom_components/linktap/valve.py
@@ -157,4 +157,3 @@ class LinktapValve(CoordinatorEntity, ValveEntity):
         _LOGGER.debug(f"Starting watering via service call for {minutes} minutes")
         await self.tap_api.turn_on(self._gw_id, self.tap_id, minutes)
         await self.coordinator.async_request_refresh()
-

--- a/custom_components/linktap/valve.py
+++ b/custom_components/linktap/valve.py
@@ -152,9 +152,9 @@ class LinktapValve(CoordinatorEntity, ValveEntity):
         await self.coordinator.async_request_refresh()
 
     async def _start_watering(self, minutes=False):
-        if not minutes:
+        if not minutes or minutes == 0:
             minutes = 1439
-        _LOGGER.debug(f"Starting watering for {minutes} minutes")
+        _LOGGER.debug(f"Starting watering via service call for {minutes} minutes")
         await self.tap_api.turn_on(self._gw_id, self.tap_id, minutes)
         await self.coordinator.async_request_refresh()
 


### PR DESCRIPTION
Rather than increasing the max value of the number entity, a new service has been created to allow valves to turn on for longer than the predefined 5-120 minutes.

valve.start_watering.
takes a single value of minutes.

If minutes is 0, it is overridden to the pre-determined (by Linktap) max of 1439