### PR TITLE
Change start watering service to seconds

### DIFF
--- a/custom_components/linktap/services.yaml
+++ b/custom_components/linktap/services.yaml
@@ -42,13 +42,13 @@ pause_valve:
       domain: valve
 
 start_watering:
-  name: Pause
+  name: Start Watering for X seconds
   description: Turn on a valve for a set time
   fields:
-    minutes:
-      name: Minutes
-      example: 1439
-      description: Duration in minutes
+    seconds:
+      name: Seconds
+      example: 900
+      description: Duration in seconds
   target:
     entity:
       integration: linktap

--- a/custom_components/linktap/valve.py
+++ b/custom_components/linktap/valve.py
@@ -155,7 +155,7 @@ class LinktapValve(CoordinatorEntity, ValveEntity):
     async def _start_watering(self, seconds=False):
         if not seconds or seconds == 0:
             seconds = 1439 * 60
-        _LOGGER.debug(f"Starting watering via service call for {seconds} minutes")
+        _LOGGER.debug(f"Starting watering via service call for {seconds} seconds")
         gw_id = self.coordinator.get_gw_id()
         await self.coordinator.tap_api.turn_on(gw_id, self.tap_id, seconds)
         await self.coordinator.async_request_refresh()

--- a/custom_components/linktap/valve.py
+++ b/custom_components/linktap/valve.py
@@ -149,7 +149,7 @@ class LinktapValve(CoordinatorEntity, ValveEntity):
             hours = 1
         _LOGGER.debug(f"Pausing {self.entity_id} for {hours} hours")
         gw_id = self.coordinator.get_gw_id()
-        await self.tap_api.pause_tap(gw_id, self.tap_id, hours)
+        await self.coordinator.tap_api.pause_tap(gw_id, self.tap_id, hours)
         await self.coordinator.async_request_refresh()
 
     async def _start_watering(self, minutes=False):
@@ -157,5 +157,5 @@ class LinktapValve(CoordinatorEntity, ValveEntity):
             minutes = 1439
         _LOGGER.debug(f"Starting watering via service call for {minutes} minutes")
         gw_id = self.coordinator.get_gw_id()
-        await self.tap_api.turn_on(gw_id, self.tap_id, minutes)
+        await self.coordinator.tap_api.turn_on(gw_id, self.tap_id, minutes)
         await self.coordinator.async_request_refresh()

--- a/custom_components/linktap/valve.py
+++ b/custom_components/linktap/valve.py
@@ -152,10 +152,10 @@ class LinktapValve(CoordinatorEntity, ValveEntity):
         await self.coordinator.tap_api.pause_tap(gw_id, self.tap_id, hours)
         await self.coordinator.async_request_refresh()
 
-    async def _start_watering(self, minutes=False):
-        if not minutes or minutes == 0:
-            minutes = 1439
-        _LOGGER.debug(f"Starting watering via service call for {minutes} minutes")
+    async def _start_watering(self, seconds=False):
+        if not seconds or seconds == 0:
+            seconds = 1439 * 60
+        _LOGGER.debug(f"Starting watering via service call for {seconds} minutes")
         gw_id = self.coordinator.get_gw_id()
-        await self.coordinator.tap_api.turn_on(gw_id, self.tap_id, minutes)
+        await self.coordinator.tap_api.turn_on(gw_id, self.tap_id, seconds)
         await self.coordinator.async_request_refresh()


### PR DESCRIPTION
The service was defined in HA as minutes, but actualy acccepts seconds.
Adjust accordingly.