### PR TITLE
Fix eventtype deprecation

### DIFF
--- a/custom_components/linktap/valve.py
+++ b/custom_components/linktap/valve.py
@@ -16,8 +16,6 @@ from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity import *
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-#from homeassistant.helpers.event import EventStateChangedData
-#from homeassistant.helpers.typing import EventType
 from homeassistant.helpers.update_coordinator import (CoordinatorEntity,
                                                       DataUpdateCoordinator)
 from homeassistant.util import slugify

--- a/custom_components/linktap/valve.py
+++ b/custom_components/linktap/valve.py
@@ -11,13 +11,13 @@ from homeassistant.components.valve import ValveEntity, ValveEntityFeature
 from homeassistant.const import (ATTR_ENTITY_ID, CONF_ENTITY_ID,
                                  SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_OFF,
                                  STATE_ON)
-from homeassistant.core import callback
+from homeassistant.core import callback, Event, EventStateChangedData
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity import *
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import EventStateChangedData
-from homeassistant.helpers.typing import EventType
+#from homeassistant.helpers.event import EventStateChangedData
+#from homeassistant.helpers.typing import EventType
 from homeassistant.helpers.update_coordinator import (CoordinatorEntity,
                                                       DataUpdateCoordinator)
 from homeassistant.util import slugify
@@ -115,7 +115,7 @@ class LinktapValve(CoordinatorEntity, ValveEntity):
 
     @callback
     def async_state_changed_listener(
-        self, event: EventType[EventStateChangedData] | None = None
+        self, event: Event[EventStateChangedData] | None = None
     ) -> None:
         """Handle child updates."""
         super().async_state_changed_listener(event)

--- a/custom_components/linktap/valve.py
+++ b/custom_components/linktap/valve.py
@@ -11,7 +11,7 @@ from homeassistant.components.valve import ValveEntity, ValveEntityFeature
 from homeassistant.const import (ATTR_ENTITY_ID, CONF_ENTITY_ID,
                                  SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_OFF,
                                  STATE_ON)
-from homeassistant.core import callback, Event, EventStateChangedData
+from homeassistant.core import Event, EventStateChangedData, callback
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity import *
 from homeassistant.helpers.entity import DeviceInfo


### PR DESCRIPTION
Replace `EventType` with `homeassistant.core.Event`