### PR TITLE
fix: use HA’s slugify for entity-id mapping

### DIFF
--- a/custom_components/linktap/switch.py
+++ b/custom_components/linktap/switch.py
@@ -82,14 +82,14 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
         return f"{MANUFACTURER} {self._name}"
 
     @property
-    def duration_entity(self):
-        name = re.sub('[^0-9a-zA-Z]+', '_', self._name)
-        return f"number.{DOMAIN}_{name}_watering_duration".lower()
+    def duration_entity(self) -> str:
+        slug = slugify(self._name)  # HA-native conversion
+        return f"number.{DOMAIN}_{slug}_watering_duration"
 
     @property
-    def volume_entity(self):
-        name = re.sub('[^0-9a-zA-Z]+', '_', self._name)
-        return f"number.{DOMAIN}_{name}_watering_volume".lower()
+    def volume_entity(self) -> str:
+        slug = slugify(self._name)
+        return f"number.{DOMAIN}_{slug}_watering_volume"
 
     async def async_turn_on(self, **kwargs):
         duration = self.get_watering_duration()


### PR DESCRIPTION
fixes: #63 

**Problem**
Current regex drops umlauts → `“Süden”` ⇒ `s_den`; Number IDs `…suden…` are not found → integration falls back to 15-min default.

**Fix**
Replace custom regex with HA’s native helper:

```python
from homeassistant.util import slugify

slug = slugify(self._name)
return f"number.{DOMAIN}_{slug}_watering_duration"
```

(and same for `_volume`).

**Result**
IDs match Home Assistant rules for any UTF-8 name; mapping reliable, no unwanted 15-min limit.
