### PR TITLE
Allow pause to accept 0 as a value, which disables the pause

### DIFF
--- a/custom_components/linktap/switch.py
+++ b/custom_components/linktap/switch.py
@@ -169,8 +169,8 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
     def device_info(self) -> DeviceInfo:
         return self._attr_device_info
 
-    async def _pause_tap(self, hours=False):
-        if not hours:
+    async def _pause_tap(self, hours=None):
+        if hours is None:
             hours = 1
         _LOGGER.debug(f"Pausing {self.entity_id} for {hours} hours")
         gw_id = self.coordinator.get_gw_id()

--- a/custom_components/linktap/valve.py
+++ b/custom_components/linktap/valve.py
@@ -142,8 +142,8 @@ class LinktapValve(CoordinatorEntity, ValveEntity):
     def device_info(self) -> DeviceInfo:
         return self._attr_device_info
 
-    async def _pause_tap(self, hours=False):
-        if not hours:
+    async def _pause_tap(self, hours=None):
+        if hours is None:
             hours = 1
         _LOGGER.debug(f"Pausing {self.entity_id} for {hours} hours")
         gw_id = self.coordinator.get_gw_id()


### PR DESCRIPTION
The underlying pause function had a check to ensure hours was sent..

A value of 0 disables pause, so a modification is needed in order to allow the 0 value, as 0 equates to False in python.