### PR TITLE
Improve API request call handling

### DIFF
--- a/custom_components/linktap/linktap_local.py
+++ b/custom_components/linktap/linktap_local.py
@@ -63,16 +63,6 @@ class LinktapLocal:
         headers = {"content-type": "application/json; charset=UTF-8"}
 
         url = "http://" + self.ip + "/api.shtml"
-        status, response = await self._make_request(url, data, headers)
-        # Every now and then, a request will throw a 404.
-        # Ive never seen it fail twice, so lets try it again.
-        if status == 404:
-            _LOGGER.debug("Got a 404 issue: Wait and try again")
-            raise JSONDecodeError("404 Not Found")
-        return response
-
-    async def _make_request(self, url, data, headers):
-        """Make the actual http request and present the status and response json"""
 
         async with aiohttp.ClientSession() as session:
             async with await session.post(url, json=data, headers=headers) as resp:
@@ -84,7 +74,12 @@ class LinktapLocal:
                     """Fallback to html wrapped"""
                     response = json.loads(self.clean_response(await resp.text()))
 
-        return status, response
+        # Every now and then, a request will throw a 404.
+        # Ive never seen it fail twice, so lets try it again.
+        if status == 404:
+            _LOGGER.debug("Got a 404 issue: Wait and try again")
+            raise JSONDecodeError("404 Not Found")
+        return response
 
     async def fetch_data(self, gw_id, dev_id):
         status = await self.get_tap_status(gw_id, dev_id)

--- a/custom_components/linktap/linktap_local.py
+++ b/custom_components/linktap/linktap_local.py
@@ -4,22 +4,11 @@ import re
 from json.decoder import JSONDecodeError
 
 import aiohttp
-from tenacity import (
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-)
+from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
+                      wait_exponential)
 
-from .const import (
-    CONFIG_CMD,
-    DEFAULT_TIME,
-    DISMISS_ALERT_CMD,
-    PAUSE_CMD,
-    START_CMD,
-    STATUS_CMD,
-    STOP_CMD,
-)
+from .const import (CONFIG_CMD, DEFAULT_TIME, DISMISS_ALERT_CMD, PAUSE_CMD,
+                    START_CMD, STATUS_CMD, STOP_CMD)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -176,4 +165,5 @@ class LinktapLocal:
             "enable": True,
         }
         status = await self._request(data)
+        return status["ret"] == 0
         return status["ret"] == 0


### PR DESCRIPTION
Apologies for the many updates, my vscode is configured to auto format using PEP8

This PR is about the API calls you make in `_request` and `_make_request`:
It joins both methods into one, leveraging the response `json()` method in favour of `.text()` `.text()` is kept as a fallback if the owner of the linktap GW hasn't removed the HTML wrapper through the GUI.
