### PR TITLE
Fix entity lookups for current HA entity IDs and safely modernize entity naming

### DIFF
--- a/custom_components/linktap/binary_sensor.py
+++ b/custom_components/linktap/binary_sensor.py
@@ -9,9 +9,11 @@ import voluptuous as vol
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.helpers import entity_platform, service
 from homeassistant.helpers.entity import *
-from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.update_coordinator import (CoordinatorEntity,
-                                                      DataUpdateCoordinator)
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
 from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,7 +50,16 @@ class LinktapBinarySensor(CoordinatorEntity, BinarySensorEntity):
     # Modern HA naming: entity name is relative to the device name.
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator: DataUpdateCoordinator, hass, tap, data_attribute, name=False, device_class=False, icon=False):
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        hass,
+        tap,
+        data_attribute,
+        name=False,
+        device_class=False,
+        icon=False,
+    ):
         super().__init__(coordinator)
         self._state = None
         if not name:
@@ -59,21 +70,37 @@ class LinktapBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self.tap_name = tap[NAME]
         self.tap_api = coordinator.tap_api
         self.platform = "binary_sensor"
+
         # IMPORTANT: keep unique_id formula unchanged for registry/history stability.
-        self._attr_unique_id = slugify(f"{DOMAIN}_{self.platform}_{data_attribute}_{self.tap_id}")
+        self._attr_unique_id = slugify(
+            f"{DOMAIN}_{self.platform}_{data_attribute}_{self.tap_id}"
+        )
+
+        # LinkTap fault/alarm flags are diagnostic information rather than
+        # ordinary operating status. Mark them DIAGNOSTIC so Home Assistant
+        # groups them accordingly while keeping them available to dashboards,
+        # automations and alert handling.
+        if data_attribute in {
+            "is_fall",
+            "is_cutoff",
+            "is_leak",
+            "is_clog",
+            "is_broken",
+        }:
+            self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
         if device_class:
             self._attr_device_class = device_class
         if icon:
             self._attr_icon = icon
+
         self._attrs = {}
         self._attr_device_info = DeviceInfo(
-            identifiers={
-                (DOMAIN, tap[TAP_ID])
-            },
+            identifiers={(DOMAIN, tap[TAP_ID])},
             name=tap[NAME],
             manufacturer=MANUFACTURER,
             model=tap[TAP_ID],
-            configuration_url="http://" + tap[GW_IP] + "/"
+            configuration_url="http://" + tap[GW_IP] + "/",
         )
 
     @property
@@ -101,7 +128,9 @@ class LinktapBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     async def _dismiss_alerts(self):
         _LOGGER.debug(f"Dismissing all alerts for {self.entity_id}")
-        await self.tap_api.dismiss_alert(self.coordinator.get_gw_id(), self.tap_id)
+        await self.tap_api.dismiss_alert(
+            self.coordinator.get_gw_id(), self.tap_id
+        )
 
     """alert: type of alert
     0: all types of alert.
@@ -113,11 +142,15 @@ class LinktapBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """
     async def _dismiss_alert(self):
         split_name = self._data_check_attribute.split("_")
-        alert_type = split_name[len(split_name)-1]
+        alert_type = split_name[len(split_name) - 1]
         alert_id = self.alert_lookup(alert_type)
         if alert_id is not None:
-            _LOGGER.debug(f"Dismissing {alert_type} alert for {self.entity_id}")
-            await self.tap_api.dismiss_alert(self.coordinator.get_gw_id(), self.tap_id)
+            _LOGGER.debug(
+                f"Dismissing {alert_type} alert for {self.entity_id}"
+            )
+            await self.tap_api.dismiss_alert(
+                self.coordinator.get_gw_id(), self.tap_id
+            )
         else:
             _LOGGER.debug("No matching alert found. Do nothing")
 
@@ -128,7 +161,7 @@ class LinktapBinarySensor(CoordinatorEntity, BinarySensorEntity):
             "shutdown": 2,
             "cutoff": 3,
             "high_flow": 4,
-            "low_flow": 5
+            "low_flow": 5,
         }
         if alert_name in alerts:
             return alerts[alert_name]

--- a/custom_components/linktap/binary_sensor.py
+++ b/custom_components/linktap/binary_sensor.py
@@ -10,10 +10,8 @@ from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.helpers import entity_platform, service
 from homeassistant.helpers.entity import *
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import (CoordinatorEntity,
+                                                      DataUpdateCoordinator)
 from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/linktap/binary_sensor.py
+++ b/custom_components/linktap/binary_sensor.py
@@ -22,12 +22,7 @@ from .const import DOMAIN, GW_ID, GW_IP, MANUFACTURER, NAME, TAP_ID
 async def async_setup_entry(
     hass, config, async_add_entities, discovery_info=None
 ):
-    """Setup the sensor platform."""
-    #config_id = config.unique_id
-    #_LOGGER.debug(f"Configuring binary sensor entities for config {config_id}")
-    #if config_id not in hass.data[DOMAIN]:
-    #    await asyncio.sleep(random.randint(1,3))
-    #taps = hass.data[DOMAIN][config_id]["conf"]["taps"]
+    """Setup the binary sensor platform."""
     taps = hass.data[DOMAIN][config.entry_id]["conf"]["taps"]
     binary_sensors = []
     for tap in taps:
@@ -37,7 +32,7 @@ async def async_setup_entry(
         binary_sensors.append(LinktapBinarySensor(coordinator, hass, tap=tap, data_attribute="is_fall", icon="mdi:meter-electric-outline"))
         binary_sensors.append(LinktapBinarySensor(coordinator, hass, tap=tap, data_attribute="is_cutoff", icon="mdi:scissors-cutting"))
         binary_sensors.append(LinktapBinarySensor(coordinator, hass, tap=tap, name="Is Leaking", data_attribute="is_leak", icon="mdi:leak"))
-        binary_sensors.append(LinktapBinarySensor(coordinator, hass, tap=tap, name="Is Clogged", data_attribute="is_clog",  icon="mdi:leak-off"))
+        binary_sensors.append(LinktapBinarySensor(coordinator, hass, tap=tap, name="Is Clogged", data_attribute="is_clog", icon="mdi:leak-off"))
         binary_sensors.append(LinktapBinarySensor(coordinator, hass, tap=tap, data_attribute="is_broken", icon="mdi:scissors-cutting"))
         binary_sensors.append(LinktapBinarySensor(coordinator, hass, tap=tap, data_attribute="is_manual_mode", icon="mdi:account-switch"))
         binary_sensors.append(LinktapBinarySensor(coordinator, hass, tap=tap, data_attribute="is_watering", icon="mdi:water"))
@@ -48,20 +43,23 @@ async def async_setup_entry(
     platform.async_register_entity_service("dismiss_alerts", {}, "_dismiss_alerts")
     platform.async_register_entity_service("dismiss_alert", {}, "_dismiss_alert")
 
+
 class LinktapBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    # Modern HA naming: entity name is relative to the device name.
+    _attr_has_entity_name = True
 
     def __init__(self, coordinator: DataUpdateCoordinator, hass, tap, data_attribute, name=False, device_class=False, icon=False):
         super().__init__(coordinator)
         self._state = None
         if not name:
             name = data_attribute.replace("_", " ").title()
-        self._name = tap[NAME] + " " + name
-        self._id = self._name
+        self._attr_name = name
         self._data_check_attribute = data_attribute
         self.tap_id = tap[TAP_ID]
         self.tap_name = tap[NAME]
         self.tap_api = coordinator.tap_api
         self.platform = "binary_sensor"
+        # IMPORTANT: keep unique_id formula unchanged for registry/history stability.
         self._attr_unique_id = slugify(f"{DOMAIN}_{self.platform}_{data_attribute}_{self.tap_id}")
         if device_class:
             self._attr_device_class = device_class
@@ -69,7 +67,6 @@ class LinktapBinarySensor(CoordinatorEntity, BinarySensorEntity):
             self._attr_icon = icon
         self._attrs = {}
         self._attr_device_info = DeviceInfo(
-            #entry_type=DeviceEntryType.SERVICE,
             identifiers={
                 (DOMAIN, tap[TAP_ID])
             },
@@ -83,10 +80,6 @@ class LinktapBinarySensor(CoordinatorEntity, BinarySensorEntity):
     def unique_id(self):
         """Return the unique ID of the sensor."""
         return self._attr_unique_id
-
-    @property
-    def name(self):
-        return f"{MANUFACTURER} {self._name}"
 
     @property
     def extra_state_attributes(self):
@@ -130,14 +123,13 @@ class LinktapBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     def alert_lookup(self, alert_name):
         alerts = {
-            "all" :0,
+            "all": 0,
             "fall": 1,
-            "shutdown" :2,
+            "shutdown": 2,
             "cutoff": 3,
             "high_flow": 4,
             "low_flow": 5
         }
         if alert_name in alerts:
             return alerts[alert_name]
-        else:
-            return None
+        return None

--- a/custom_components/linktap/number.py
+++ b/custom_components/linktap/number.py
@@ -23,12 +23,12 @@ async def async_setup_entry(
     taps = hass.data[DOMAIN][config.entry_id]["conf"]["taps"]
     numbers = []
     for tap in taps:
-        """For each tap, we set a number for duration, volume, and pause duration"""
+        """For each tap, we set a number for duration, volume, and water-plan pause duration"""
         _LOGGER.debug(f"Configuring numbers for tap {tap}")
         coordinator = tap["coordinator"]
         numbers.append(LinktapNumber(coordinator, hass, tap, "Watering duration", "mdi:clock", "m"))
         numbers.append(LinktapNumber(coordinator, hass, tap, "Watering volume", "mdi:water", hass.data[DOMAIN][config.entry_id]["conf"]["vol_unit"]))
-        numbers.append(LinktapPauseDurationNumber(coordinator, hass, tap, "Pause duration", "mdi:timer-pause", "h"))
+        numbers.append(LinktapPauseDurationNumber(coordinator, hass, tap, "Pause Duration Water Plan", "mdi:timer-pause", "h"))
 
     async_add_entities(numbers, True)
 
@@ -111,8 +111,14 @@ class LinktapPauseDurationNumber(CoordinatorEntity, RestoreNumber):
         self._name = tap[NAME]
         self.tap_id = tap[TAP_ID]
         self.platform = "number"
-        # IMPORTANT: keep unique_id formula unchanged for registry/history stability.
-        self._attr_unique_id = slugify(f"{DOMAIN}_{self.platform}_{self.tap_id}_pause_duration")
+
+        # IMPORTANT: unique_id is intentionally unchanged. Although the displayed
+        # name is now "Pause Duration Water Plan", registry/history must remain
+        # tied to the existing pause_duration entity.
+        self._attr_unique_id = slugify(
+            f"{DOMAIN}_{self.platform}_{self.tap_id}_pause_duration"
+        )
+
         self._attr_name = number_suffix
         self._attr_native_min_value = 1
         self._attr_native_max_value = 240

--- a/custom_components/linktap/number.py
+++ b/custom_components/linktap/number.py
@@ -20,24 +20,23 @@ async def async_setup_entry(
     hass, config, async_add_entities, discovery_info=None
 ):
     """Setup the number platform."""
-    #config_id = config.unique_id
-    #_LOGGER.debug(f"Configuring number entities for config {config_id}")
-    #if config_id not in hass.data[DOMAIN]:
-    #    await asyncio.sleep(random.randint(1,3))
-    #taps = hass.data[DOMAIN][config_id]["conf"]["taps"]
     taps = hass.data[DOMAIN][config.entry_id]["conf"]["taps"]
     numbers = []
     for tap in taps:
         """For each tap, we set a number for duration, volume, and pause duration"""
         _LOGGER.debug(f"Configuring numbers for tap {tap}")
         coordinator = tap["coordinator"]
-        numbers.append(LinktapNumber(coordinator, hass, tap, "Watering Duration", "mdi:clock", "m"))
-        numbers.append(LinktapNumber(coordinator, hass, tap, "Watering Volume", "mdi:water", hass.data[DOMAIN][config.entry_id]["conf"]["vol_unit"]))
-        numbers.append(LinktapPauseDurationNumber(coordinator, hass, tap, "Pause Duration", "mdi:timer-pause", "h"))
+        numbers.append(LinktapNumber(coordinator, hass, tap, "Watering duration", "mdi:clock", "m"))
+        numbers.append(LinktapNumber(coordinator, hass, tap, "Watering volume", "mdi:water", hass.data[DOMAIN][config.entry_id]["conf"]["vol_unit"]))
+        numbers.append(LinktapPauseDurationNumber(coordinator, hass, tap, "Pause duration", "mdi:timer-pause", "h"))
 
     async_add_entities(numbers, True)
 
+
 class LinktapNumber(CoordinatorEntity, RestoreNumber):
+    # Modern HA naming: entity name is relative to the device name.
+    _attr_has_entity_name = True
+
     def __init__(self, coordinator: DataUpdateCoordinator, hass, tap, number_suffix, icon, unit_of_measurement):
         super().__init__(coordinator)
         self._state = None
@@ -45,15 +44,17 @@ class LinktapNumber(CoordinatorEntity, RestoreNumber):
         self._id = self._name
         self.tap_id = tap[TAP_ID]
         self.platform = "number"
+        # IMPORTANT: keep unique_id formula unchanged for registry/history stability.
         self._attr_unique_id = slugify(f"{DOMAIN}_{self.platform}_{self.tap_id}_{number_suffix.replace(' ', '_')}")
+        self._attr_name = number_suffix
         self._attr_native_min_value = 0
         self._attr_native_max_value = 120
         self._attr_native_step = 5
-        if number_suffix == "Watering Volume":
+        if number_suffix == "Watering volume":
             self._attr_native_max_value = 2000
             self._attr_native_step = 10
-        self._attr_native_unit_of_measurement = unit_of_measurement#"m"
-        self._attr_icon = icon#"mdi:clock"
+        self._attr_native_unit_of_measurement = unit_of_measurement
+        self._attr_icon = icon
         self.number_suffix = number_suffix
         self._attr_device_info = DeviceInfo(
             identifiers={
@@ -74,8 +75,8 @@ class LinktapNumber(CoordinatorEntity, RestoreNumber):
             _LOGGER.debug(f"Restoring value to {restored_number.native_value}")
             self._attr_native_value = restored_number.native_value
         else:
-            _LOGGER.debug(f"No value found to restore -- setting default")
-            if self.number_suffix == "Watering Volume":
+            _LOGGER.debug("No value found to restore -- setting default")
+            if self.number_suffix == "Watering volume":
                 self._attr_native_value = DEFAULT_VOL
             else:
                 self._attr_native_value = DEFAULT_TIME
@@ -90,10 +91,6 @@ class LinktapNumber(CoordinatorEntity, RestoreNumber):
         return self._attrs
 
     @property
-    def name(self):
-        return f"{MANUFACTURER} {self._name} {self.number_suffix}"#Watering Duration"
-
-    @property
     def device_info(self) -> DeviceInfo:
         return self._attr_device_info
 
@@ -103,14 +100,20 @@ class LinktapNumber(CoordinatorEntity, RestoreNumber):
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
+
 class LinktapPauseDurationNumber(CoordinatorEntity, RestoreNumber):
+    # Modern HA naming: entity name is relative to the device name.
+    _attr_has_entity_name = True
+
     def __init__(self, coordinator: DataUpdateCoordinator, hass, tap, number_suffix, icon, unit_of_measurement):
         super().__init__(coordinator)
         self._state = None
         self._name = tap[NAME]
         self.tap_id = tap[TAP_ID]
         self.platform = "number"
+        # IMPORTANT: keep unique_id formula unchanged for registry/history stability.
         self._attr_unique_id = slugify(f"{DOMAIN}_{self.platform}_{self.tap_id}_pause_duration")
+        self._attr_name = number_suffix
         self._attr_native_min_value = 1
         self._attr_native_max_value = 240
         self._attr_native_step = 1
@@ -135,7 +138,7 @@ class LinktapPauseDurationNumber(CoordinatorEntity, RestoreNumber):
             _LOGGER.debug(f"Restoring pause duration value to {restored_number.native_value}")
             self._attr_native_value = restored_number.native_value
         else:
-            _LOGGER.debug(f"No pause duration value found to restore -- setting default to 24")
+            _LOGGER.debug("No pause duration value found to restore -- setting default to 24")
             self._attr_native_value = 24
         self.async_write_ha_state()
 
@@ -146,10 +149,6 @@ class LinktapPauseDurationNumber(CoordinatorEntity, RestoreNumber):
     @property
     def extra_state_attributes(self):
         return self._attrs
-
-    @property
-    def name(self):
-        return f"{MANUFACTURER} {self._name} Pause Duration"
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/linktap/sensor.py
+++ b/custom_components/linktap/sensor.py
@@ -7,11 +7,8 @@ import aiohttp
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 import voluptuous as vol
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-    SensorEntity,
-    SensorStateClass,
-)
+from homeassistant.components.sensor import (SensorDeviceClass, SensorEntity,
+                                             SensorStateClass)
 from homeassistant.const import UnitOfVolumeFlowRate
 from homeassistant.helpers.entity import *
 from homeassistant.helpers.entity import DeviceInfo

--- a/custom_components/linktap/sensor.py
+++ b/custom_components/linktap/sensor.py
@@ -132,6 +132,20 @@ class LinktapSensor(CoordinatorEntity, SensorEntity):
         else:
             if self.attribute == "plan_mode_string":
                 self._state = self.translate_plan_mode(attributes["plan_mode"])
+            elif self.attribute == "remain_duration":
+                # LinkTap can retain the final remaining-duration value after a
+                # watering session is stopped. In Home Assistant, a remaining
+                # duration is semantically zero when watering is no longer active.
+                #
+                # Preserve the reported remaining duration while paused so a
+                # paused watering session can still show how much time remains.
+                is_watering = bool(attributes.get("is_watering", False))
+                is_paused = bool(attributes.get("is_paused", False))
+                self._state = (
+                    attributes[self.attribute]
+                    if is_watering or is_paused
+                    else 0
+                )
             else:
                 self._state = attributes[self.attribute]
 

--- a/custom_components/linktap/sensor.py
+++ b/custom_components/linktap/sensor.py
@@ -19,7 +19,6 @@ _LOGGER = logging.getLogger(__name__)
 
 from .const import DOMAIN, GW_ID, GW_IP, MANUFACTURER, NAME, TAP_ID
 
-_LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass, config, async_add_entities, discovery_info=None
@@ -46,19 +45,22 @@ async def async_setup_entry(
         sensors.append(LinktapSensor(coordinator, hass, tap, data_attribute="plan_mode_string", unit="mode", icon="mdi:note"))
     async_add_entities(sensors, True)
 
+
 class LinktapSensor(CoordinatorEntity, SensorEntity):
+    # Modern HA naming: entity name is relative to the device name.
+    _attr_has_entity_name = True
 
     def __init__(self, coordinator: DataUpdateCoordinator, hass, tap, data_attribute, unit, device_class=False, icon=False):
         super().__init__(coordinator)
         name = data_attribute.replace("_", " ").title()
         self._state = None
-        self._name = tap[NAME] + " " + name
-        self._id = self._name
         self.attribute = data_attribute
         self.tap_id = tap[TAP_ID]
         self.tap_name = tap[NAME]
         self.platform = "sensor"
+        # IMPORTANT: keep unique_id formula unchanged for registry/history stability.
         self._attr_unique_id = slugify(f"{DOMAIN}_{self.platform}_{data_attribute}_{self.tap_id}")
+        self._attr_name = name
         self._attrs = {
             "unit_of_measurement": unit
         }
@@ -78,11 +80,12 @@ class LinktapSensor(CoordinatorEntity, SensorEntity):
             model=tap[TAP_ID],
             configuration_url="http://" + tap[GW_IP] + "/"
         )
-#Modemode: watering mode (1 - Instant Mode, 2 - Calendar mode, 3 - 7 day mode, 4 - Odd-even mode, 5 -Interval mode, 6 - Month mode).
+
+    # Modemode: watering mode (1 - Instant Mode, 2 - Calendar mode,
+    # 3 - 7 day mode, 4 - Odd-even mode, 5 - Interval mode, 6 - Month mode).
     def translate_plan_mode(self, mode):
         modes = ['NA', 'Instant', 'Calendar', '7-Day', 'Odd-Even', 'Interval', 'Month']
         return modes[mode]
-
 
     @property
     def unique_id(self):
@@ -90,19 +93,13 @@ class LinktapSensor(CoordinatorEntity, SensorEntity):
         return self._attr_unique_id
 
     @property
-    def name(self):
-        return f"{MANUFACTURER} {self._id}"
-
-    @property
     def extra_state_attributes(self):
         return self._attrs
 
     @property
     def state(self):
-
         attributes = self.coordinator.data
         _LOGGER.debug(f"Sensor state: {attributes}")
-        previous_state = self._state
         if not attributes:
             self._state = "unknown"
         else:
@@ -119,11 +116,14 @@ class LinktapSensor(CoordinatorEntity, SensorEntity):
 
 
 class LinktapVolumeTotalSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
+    # Modern HA naming: entity name is relative to the device name.
+    _attr_has_entity_name = True
 
     def __init__(self, coordinator, hass, tap, unit):
         super().__init__(coordinator)
         self.tap_id = tap[TAP_ID]
-        self._attr_name = f"{MANUFACTURER} {tap[NAME]} Volume Total"
+        self._attr_name = "Volume Total"
+        # IMPORTANT: keep unique_id formula unchanged for registry/history stability.
         self._attr_unique_id = slugify(f"{DOMAIN}_sensor_volume_total_{self.tap_id}")
         self._attr_native_unit_of_measurement = unit
         self._attr_device_class = "water"
@@ -171,11 +171,14 @@ class LinktapVolumeTotalSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
 
 
 class LinktapWateringTimeTotalSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
+    # Modern HA naming: entity name is relative to the device name.
+    _attr_has_entity_name = True
 
     def __init__(self, coordinator, hass, tap):
         super().__init__(coordinator)
         self.tap_id = tap[TAP_ID]
-        self._attr_name = f"{MANUFACTURER} {tap[NAME]} Watering Time Total"
+        self._attr_name = "Watering Time Total"
+        # IMPORTANT: keep unique_id formula unchanged for registry/history stability.
         self._attr_unique_id = slugify(f"{DOMAIN}_sensor_watering_time_total_{self.tap_id}")
         self._attr_native_unit_of_measurement = "s"
         self._attr_state_class = SensorStateClass.TOTAL_INCREASING

--- a/custom_components/linktap/sensor.py
+++ b/custom_components/linktap/sensor.py
@@ -7,7 +7,12 @@ import aiohttp
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 import voluptuous as vol
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.const import UnitOfVolumeFlowRate
 from homeassistant.helpers.entity import *
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -26,6 +31,15 @@ async def async_setup_entry(
     """Setup the sensor platform."""
     taps = hass.data[DOMAIN][config.entry_id]["conf"]["taps"]
     vol_unit = hass.data[DOMAIN][config.entry_id]["conf"]["vol_unit"]
+
+    # Home Assistant requires canonical volume-flow units for the
+    # VOLUME_FLOW_RATE device class and long-term statistics.
+    # LinkTap reports the configured volume unit as L or Gal.
+    flow_unit = (
+        UnitOfVolumeFlowRate.LITERS_PER_MINUTE
+        if str(vol_unit).lower() == "l"
+        else UnitOfVolumeFlowRate.GALLONS_PER_MINUTE
+    )
     sensors = []
     for tap in taps:
         _LOGGER.debug(f"Configuring sensors for tap {tap}")
@@ -35,7 +49,17 @@ async def async_setup_entry(
         sensors.append(LinktapSensor(coordinator, hass, tap, data_attribute="total_duration", unit="s", icon="mdi:clock"))
         sensors.append(LinktapSensor(coordinator, hass, tap, data_attribute="remain_duration", unit="s", icon="mdi:clock"))
         sensors.append(LinktapWateringTimeTotalSensor(coordinator, hass, tap))
-        sensors.append(LinktapSensor(coordinator, hass, tap, data_attribute="speed", unit=f"{vol_unit}pm", icon="mdi:speedometer"))
+        sensors.append(
+            LinktapSensor(
+                coordinator,
+                hass,
+                tap,
+                data_attribute="speed",
+                unit=flow_unit,
+                device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
+                icon="mdi:speedometer",
+            )
+        )
         sensors.append(LinktapSensor(coordinator, hass, tap, data_attribute="volume", unit=vol_unit, device_class="water", icon="mdi:water-percent"))
         sensors.append(LinktapSensor(coordinator, hass, tap, data_attribute="volume_limit", unit=vol_unit, icon="mdi:water-percent"))
         sensors.append(LinktapVolumeTotalSensor(coordinator, hass, tap, unit=vol_unit))
@@ -68,7 +92,10 @@ class LinktapSensor(CoordinatorEntity, SensorEntity):
             self._attr_icon = icon
         if device_class:
             self._attr_device_class = device_class
-            if device_class == "water":
+            if device_class in (
+                "water",
+                SensorDeviceClass.VOLUME_FLOW_RATE,
+            ):
                 self._attr_state_class = SensorStateClass.MEASUREMENT
 
         self._attr_device_info = DeviceInfo(

--- a/custom_components/linktap/switch.py
+++ b/custom_components/linktap/switch.py
@@ -10,8 +10,9 @@ import voluptuous as vol
 from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import STATE_UNKNOWN
-from homeassistant.helpers import entity_platform, service
+from homeassistant.helpers import entity_platform
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import service
 from homeassistant.helpers.entity import *
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/custom_components/linktap/switch.py
+++ b/custom_components/linktap/switch.py
@@ -9,7 +9,7 @@ import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.const import STATE_UNKNOWN
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import service
@@ -123,9 +123,9 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
             )
             duration = DEFAULT_TIME
             self._attrs[ATTR_DEFAULT_TIME] = True
-        elif entity.state == STATE_UNKNOWN:
+        elif entity.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             _LOGGER.debug(
-                f"Entity {entity_id} state unknown -- setting default"
+                f"Entity {entity_id} state {entity.state} -- setting default"
             )
             duration = DEFAULT_TIME
             self._attrs[ATTR_DEFAULT_TIME] = True
@@ -144,10 +144,10 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
                 "Watering volume entity could not be resolved -- setting default"
             )
             self._attrs[ATTR_VOL] = False
-        elif entity.state == STATE_UNKNOWN:
+        elif entity.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             volume = DEFAULT_VOL
             _LOGGER.debug(
-                f"Entity {entity_id} state unknown -- setting default"
+                f"Entity {entity_id} state {entity.state} -- setting default"
             )
             self._attrs[ATTR_VOL] = False
         elif int(float(entity.state)) == 0:
@@ -250,7 +250,7 @@ class LinktapPauseSwitch(CoordinatorEntity, SwitchEntity):
         entity_id = self.pause_duration_entity
         _LOGGER.debug(f"PauseSwitch: Looking for {entity_id}")
         entity = self.hass.states.get(entity_id) if entity_id else None
-        if entity and entity.state not in (None, "unknown"):
+        if entity and entity.state not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             _LOGGER.debug(
                 f"PauseSwitch: Found pause duration entity {entity_id} "
                 f"with state {entity.state}"

--- a/custom_components/linktap/switch.py
+++ b/custom_components/linktap/switch.py
@@ -203,18 +203,24 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
 
 
 class LinktapPauseSwitch(CoordinatorEntity, SwitchEntity):
-    # Modern HA naming: entity name is relative to the device name.
+    # Modern HA naming: this controls LinkTap's watering-plan suspension,
+    # not pause/resume of the current watering session.
     _attr_has_entity_name = True
-    _attr_name = "Pause"
+    _attr_name = "Pause Water Plan"
 
     def __init__(self, coordinator: DataUpdateCoordinator, hass, tap):
         super().__init__(coordinator)
-        self._name = f"Pause {tap[NAME]}"
+        self._name = f"Pause Water Plan {tap[NAME]}"
         self.tap_name = tap[NAME]
         self.tap_id = tap[TAP_ID]
         self.platform = "switch"
         self.hass = hass
-        self._attr_unique_id = slugify(f"{DOMAIN}_{self.platform}_{self.tap_id}_pause")
+
+        # IMPORTANT: unique_id is intentionally unchanged so existing entity
+        # registry/history remains attached to the same entity.
+        self._attr_unique_id = slugify(
+            f"{DOMAIN}_{self.platform}_{self.tap_id}_pause"
+        )
         self._attr_icon = "mdi:pause-circle"
         self._attr_device_info = DeviceInfo(
             identifiers={
@@ -269,6 +275,8 @@ class LinktapPauseSwitch(CoordinatorEntity, SwitchEntity):
         await self.coordinator.async_request_refresh()
 
     async def _pause_tap(self, hours):
-        _LOGGER.debug(f"PauseSwitch: Pausing {self.entity_id} for {hours} hours")
+        _LOGGER.debug(
+            f"Pause Water Plan: setting {self.entity_id} for {hours} hours"
+        )
         gw_id = self.coordinator.get_gw_id()
         await self.coordinator.tap_api.pause_tap(gw_id, self.tap_id, hours)

--- a/custom_components/linktap/switch.py
+++ b/custom_components/linktap/switch.py
@@ -7,9 +7,11 @@ import re
 import aiohttp
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
+from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.helpers import entity_platform, service
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import *
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -22,6 +24,19 @@ _LOGGER = logging.getLogger(__name__)
 from .const import (ATTR_DEFAULT_TIME, ATTR_DURATION, ATTR_STATE, ATTR_VOL,
                     ATTR_VOLUME, DEFAULT_TIME, DEFAULT_VOL, DOMAIN, GW_ID,
                     GW_IP, MANUFACTURER, NAME, TAP_ID)
+
+
+def _number_entity_id(hass, tap_id, suffix):
+    """Resolve a LinkTap number entity by its stable unique ID.
+
+    Do not construct an entity_id from the tap name. Home Assistant entity IDs
+    can include area/device components and can also be renamed by the user.
+    The unique ID is stable and is the correct registry key for sibling lookup.
+    """
+    unique_id = slugify(f"{DOMAIN}_number_{tap_id}_{suffix}")
+    return er.async_get(hass).async_get_entity_id(
+        NUMBER_DOMAIN, DOMAIN, unique_id
+    )
 
 
 async def async_setup_entry(
@@ -43,7 +58,12 @@ async def async_setup_entry(
         "_pause_tap"
         )
 
+
 class LinktapSwitch(CoordinatorEntity, SwitchEntity):
+    # Modern HA naming: this is a main feature of the device.
+    _attr_has_entity_name = True
+    _attr_name = None
+
     def __init__(self, coordinator: DataUpdateCoordinator, hass, tap):
         super().__init__(coordinator)
         self._state = None
@@ -57,8 +77,6 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
         self._attr_icon = "mdi:water-pump"
         self._attrs = {
             "data": self.coordinator.data,
-            "duration_entity": self.duration_entity,
-            "volume_entity": self.volume_entity
         }
         self._attr_device_info = DeviceInfo(
             identifiers={
@@ -74,24 +92,20 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
         return self._attr_unique_id
 
     @property
-    def name(self):
-        return f"{MANUFACTURER} {self._name}"
+    def duration_entity(self):
+        return _number_entity_id(self.hass, self.tap_id, "watering_duration")
 
     @property
-    def duration_entity(self) -> str:
-        slug = slugify(self._name)  # HA-native conversion
-        return f"number.{DOMAIN}_{slug}_watering_duration"
-
-    @property
-    def volume_entity(self) -> str:
-        slug = slugify(self._name)
-        return f"number.{DOMAIN}_{slug}_watering_volume"
+    def volume_entity(self):
+        return _number_entity_id(self.hass, self.tap_id, "watering_volume")
 
     async def async_turn_on(self, **kwargs):
         duration = self.get_watering_duration()
         seconds = int(float(duration)) * 60
         gw_id = self.coordinator.get_gw_id()
-        attributes = await self.tap_api.turn_on(gw_id, self.tap_id, seconds, self.get_watering_volume())
+        attributes = await self.tap_api.turn_on(
+            gw_id, self.tap_id, seconds, self.get_watering_volume()
+        )
         await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs):
@@ -100,13 +114,18 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
         await self.coordinator.async_request_refresh()
 
     def get_watering_duration(self):
-        entity = self.hass.states.get(self.duration_entity)
+        entity_id = self.duration_entity
+        entity = self.hass.states.get(entity_id) if entity_id else None
         if not entity:
-            _LOGGER.debug(f"Entity {self.duration_entity} not found -- setting default")
+            _LOGGER.debug(
+                "Watering duration entity could not be resolved -- setting default"
+            )
             duration = DEFAULT_TIME
             self._attrs[ATTR_DEFAULT_TIME] = True
         elif entity.state == STATE_UNKNOWN:
-            _LOGGER.debug(f"Entity {self.duration_entity} state unknown -- setting default")
+            _LOGGER.debug(
+                f"Entity {entity_id} state unknown -- setting default"
+            )
             duration = DEFAULT_TIME
             self._attrs[ATTR_DEFAULT_TIME] = True
         else:
@@ -116,18 +135,23 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
         return duration
 
     def get_watering_volume(self):
-        entity = self.hass.states.get(self.volume_entity)
+        entity_id = self.volume_entity
+        entity = self.hass.states.get(entity_id) if entity_id else None
         if not entity:
             volume = DEFAULT_VOL
-            _LOGGER.debug(f"Entity {self.volume_entity} not found -- setting default")
+            _LOGGER.debug(
+                "Watering volume entity could not be resolved -- setting default"
+            )
             self._attrs[ATTR_VOL] = False
         elif entity.state == STATE_UNKNOWN:
             volume = DEFAULT_VOL
-            _LOGGER.debug(f"Entity {self.volume_entity} state unknown -- setting default")
+            _LOGGER.debug(
+                f"Entity {entity_id} state unknown -- setting default"
+            )
             self._attrs[ATTR_VOL] = False
         elif int(float(entity.state)) == 0:
             volume = entity.state
-            _LOGGER.debug(f"Entity {self.volume_entity} set to 0 -- ignore")
+            _LOGGER.debug(f"Entity {entity_id} set to 0 -- ignore")
             self._attrs[ATTR_VOL] = False
         else:
             volume = entity.state
@@ -137,6 +161,9 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
 
     @property
     def extra_state_attributes(self):
+        # Resolve dynamically so HA/user entity-id renames are followed.
+        self._attrs["duration_entity"] = self.duration_entity
+        self._attrs["volume_entity"] = self.volume_entity
         return self._attrs
 
     @property
@@ -154,7 +181,7 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
             state = "on"
         elif not status[ATTR_STATE]:
             state = "off"
-            _LOGGER.debug(f"Switch {self.name} state {state}")
+            _LOGGER.debug(f"Switch {self.entity_id} state {state}")
         return state
 
     @property
@@ -173,11 +200,16 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
         await self.tap_api.pause_tap(gw_id, self.tap_id, hours)
         await self.coordinator.async_request_refresh()
 
+
 class LinktapPauseSwitch(CoordinatorEntity, SwitchEntity):
+    # Modern HA naming: entity name is relative to the device name.
+    _attr_has_entity_name = True
+    _attr_name = "Pause"
+
     def __init__(self, coordinator: DataUpdateCoordinator, hass, tap):
         super().__init__(coordinator)
         self._name = f"Pause {tap[NAME]}"
-        self.tap_name = tap[NAME]  # Store original tap name for correct slug
+        self.tap_name = tap[NAME]
         self.tap_id = tap[TAP_ID]
         self.platform = "switch"
         self.hass = hass
@@ -199,13 +231,8 @@ class LinktapPauseSwitch(CoordinatorEntity, SwitchEntity):
         return self._attr_unique_id
 
     @property
-    def name(self):
-        return self._name
-
-    @property
-    def pause_duration_entity(self) -> str:
-        slug = slugify(self.tap_name)  # Use original tap name, not self._name
-        return f"number.{DOMAIN}_{slug}_pause_duration"
+    def pause_duration_entity(self):
+        return _number_entity_id(self.hass, self.tap_id, "pause_duration")
 
     @property
     def is_on(self):
@@ -214,18 +241,25 @@ class LinktapPauseSwitch(CoordinatorEntity, SwitchEntity):
 
     @property
     def extra_state_attributes(self):
+        self._attrs["pause_duration_entity"] = self.pause_duration_entity
         return self._attrs
 
     async def async_turn_on(self, **kwargs):
         hours = 24
-        _LOGGER.debug(f"PauseSwitch: Looking for {self.pause_duration_entity}")
-        entity = self.hass.states.get(self.pause_duration_entity)
+        entity_id = self.pause_duration_entity
+        _LOGGER.debug(f"PauseSwitch: Looking for {entity_id}")
+        entity = self.hass.states.get(entity_id) if entity_id else None
         if entity and entity.state not in (None, "unknown"):
-            _LOGGER.debug(f"PauseSwitch: Found pause duration entity {self.pause_duration_entity} with state {entity.state}")
+            _LOGGER.debug(
+                f"PauseSwitch: Found pause duration entity {entity_id} "
+                f"with state {entity.state}"
+            )
             try:
                 hours = int(float(entity.state))
             except Exception as e:
-                _LOGGER.warning(f"PauseSwitch: Could not parse pause duration, using default 1: {e}")
+                _LOGGER.warning(
+                    f"PauseSwitch: Could not parse pause duration, using default 24: {e}"
+                )
         await self._pause_tap(hours=hours)
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/linktap/valve.py
+++ b/custom_components/linktap/valve.py
@@ -12,7 +12,9 @@ from homeassistant.const import (ATTR_ENTITY_ID, CONF_ENTITY_ID,
                                  SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_OFF,
                                  STATE_ON)
 from homeassistant.core import Event, EventStateChangedData, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import *
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -23,6 +25,14 @@ from homeassistant.util import slugify
 _LOGGER = logging.getLogger(__name__)
 
 from .const import ATTR_STATE, DOMAIN, GW_IP, MANUFACTURER, NAME, TAP_ID
+
+
+def _switch_entity_id(hass, tap_id):
+    """Resolve the LinkTap switch by stable unique ID, not generated entity ID."""
+    unique_id = slugify(f"{DOMAIN}_switch_{tap_id}")
+    return er.async_get(hass).async_get_entity_id(
+        SWITCH_DOMAIN, DOMAIN, unique_id
+    )
 
 
 async def async_setup_entry(
@@ -47,7 +57,12 @@ async def async_setup_entry(
         "_start_watering"
         )
 
+
 class LinktapValve(CoordinatorEntity, ValveEntity):
+    # Modern HA naming: this is a main feature of the device.
+    _attr_has_entity_name = True
+    _attr_name = None
+
     def __init__(self, coordinator: DataUpdateCoordinator, hass, tap):
         super().__init__(coordinator)
         self._state = None
@@ -60,7 +75,6 @@ class LinktapValve(CoordinatorEntity, ValveEntity):
         self._attr_unique_id = slugify(f"{DOMAIN}_{self.platform}_{self.tap_id}")
         self._attrs = {
             "data": self.coordinator.data,
-            "switch": self.switch_entity,
         }
         self._attr_device_info = DeviceInfo(
             identifiers={
@@ -76,21 +90,24 @@ class LinktapValve(CoordinatorEntity, ValveEntity):
         return self._attr_unique_id
 
     @property
-    def name(self):
-        return f"{MANUFACTURER} {self._name}"
-
-    @property
     def switch_entity(self):
-        name = self._name.replace(" ", "_")
-        name = name.replace("-", "_")
-        return f"switch.{DOMAIN}_{name}".lower()
+        return _switch_entity_id(self.hass, self.tap_id)
+
+    def _require_switch_entity(self):
+        entity_id = self.switch_entity
+        if entity_id is None:
+            raise HomeAssistantError(
+                f"Unable to resolve LinkTap switch entity for tap {self.tap_id}"
+            )
+        return entity_id
 
     async def async_open_valve(self, **kwargs):
         """Open the valve."""
+        switch_entity = self._require_switch_entity()
         await self.hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: self.switch_entity},
+            {ATTR_ENTITY_ID: switch_entity},
             blocking=True,
             context=self._context,
         )
@@ -98,10 +115,11 @@ class LinktapValve(CoordinatorEntity, ValveEntity):
 
     async def async_close_valve(self, **kwargs):
         """Close valve."""
+        switch_entity = self._require_switch_entity()
         await self.hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_OFF,
-            {ATTR_ENTITY_ID: self.switch_entity},
+            {ATTR_ENTITY_ID: switch_entity},
             blocking=True,
             context=self._context,
         )
@@ -109,6 +127,8 @@ class LinktapValve(CoordinatorEntity, ValveEntity):
 
     @property
     def extra_state_attributes(self):
+        # Resolve dynamically so HA/user entity-id renames are followed.
+        self._attrs["switch"] = self.switch_entity
         return self._attrs
 
     @callback
@@ -117,24 +137,27 @@ class LinktapValve(CoordinatorEntity, ValveEntity):
     ) -> None:
         """Handle child updates."""
         super().async_state_changed_listener(event)
+        switch_entity = self.switch_entity
         if (
             not self.available
-            or (state := self.hass.states.get(self.switch_entity)) is None
+            or switch_entity is None
+            or (state := self.hass.states.get(switch_entity)) is None
         ):
             return
 
-        self._attr_is_closed = self._attrs[ATTR_STATE] != STATE_ON
+        self._attr_is_closed = state.state != STATE_ON
 
     @property
     def state(self):
         status = self.coordinator.data
+        self._attrs["data"] = status
         self._attrs[ATTR_STATE] = status[ATTR_STATE]
         state = "unknown"
         if status[ATTR_STATE]:
             state = "open"
         elif not status[ATTR_STATE]:
             state = "closed"
-            _LOGGER.debug(f"Valve {self.name} state {state}")
+            _LOGGER.debug(f"Valve {self.entity_id} state {state}")
         self._attr_is_closed = state != "open"
         return state
 


### PR DESCRIPTION
## Summary

This PR improves LinkTap compatibility with current Home Assistant and fixes several issues identified and tested on a live LinkTap G2S installation.

The main functional fix removes LinkTap's dependency on constructing sibling `entity_id` strings from tap names. Internal relationships now resolve entities through Home Assistant's Entity Registry using their existing stable `unique_id` values. This means renamed or recreated entity IDs, including Home Assistant's newer Entity ID formats with device/area components, no longer break watering duration, watering volume, pause duration, or valve control.

The original issue was reproduced while replacing a failed LinkTap controller with a new G2S water timer. The new timer was named `G2S01` in LinkTap Web, while the local LinkTap HTTP API initially reported the generic name `TapLinker`. Home Assistant generated an entity ID such as:

`number.garden_back_g2_s_01_linktap_taplinker_watering_duration`

The integration, however, constructed and looked for:

`number.linktap_taplinker_watering_duration`

Because that entity did not exist, the integration silently fell back to the default **15-minute watering duration**.

The PR also updates LinkTap entities to Home Assistant's current device-relative naming model while preserving existing unique IDs, adds proper flow-rate metadata so the flow sensor supports Home Assistant statistics and the Energy dashboard water section, safely handles temporary `unknown` / `unavailable` number-helper states, and includes several additional entity-behaviour and presentation fixes discovered during live G2S testing.

Additional improvements now included in this PR:

- `remain_duration` now reports `0` when watering has stopped instead of retaining the gateway's stale final remaining-duration value. The reported remaining duration is retained while the LinkTap water plan is paused.
- LinkTap fault indicators for fall, water cutoff, leaking, clogging, and broken-device conditions are now categorised as Home Assistant `DIAGNOSTIC` entities rather than ordinary operational entities.
- The existing LinkTap plan-pause controls have clearer names:
  - `Pause` → `Pause Water Plan`
  - `Pause Duration` → `Pause Duration Water Plan`

  This distinguishes LinkTap's water-plan suspension function from a conventional pause/resume of the currently running watering session.
- Existing entity IDs and unique IDs are intentionally preserved; these changes do not require an entity migration.

**Root cause**

switch.py derives the Watering Duration, Watering Volume and Pause Duration entity IDs from the LinkTap tap name. valve.py similarly derives the backing switch entity ID from the tap name.

**_That assumes Home Assistant will always generate one specific entity_id string. This is no longer safe because entity IDs may contain device/area components, may be recreated using a different Entity ID format, and may be renamed by the user._**

The integration already has stable hardware-based unique_id values for these entities, so those should be used as the relationship key instead.

**Changes**

**Functional compatibility**
- Resolve Watering Duration via the Home Assistant Entity Registry using its existing stable `unique_id`.
- Resolve Watering Volume the same way.
- Resolve Pause Duration the same way.
- Resolve the valve's backing switch via the Entity Registry and the switch's stable `unique_id`.
- Resolve these relationships dynamically so later entity-ID renames/recreation continue to work.
- Preserve the existing `unique_id` formulas; no migration of entity identity is required.
- Raise a clear Home Assistant error if the valve cannot resolve its backing switch rather than sending a service call to a guessed/non-existent entity ID.
- Safely handle temporary `unknown` / `unavailable` states from LinkTap number helpers instead of attempting numeric conversion and raising errors.

**Sensor behaviour and metadata**
- Add proper Home Assistant `volume_flow_rate` metadata and `measurement` state class to the LinkTap flow-rate sensor.
- Use Home Assistant's canonical flow-rate units (`L/min` or `gal/min`) so the flow sensor can participate in statistics and the Energy dashboard water section.
- Correct `remain_duration` behaviour so it reports `0` when watering has stopped instead of retaining the gateway's stale final remaining-duration value.
- Preserve the reported remaining duration while LinkTap's water plan is paused.

**Diagnostics**
- Categorise LinkTap fault indicators as Home Assistant `DIAGNOSTIC` entities:
  - fall
  - water cutoff
  - leaking
  - clogging
  - broken-device condition
- Leave operational status entities such as linked, manual mode, watering and paused as normal device entities.

**Water-plan pause naming**
- Rename the displayed `Pause` entity to `Pause Water Plan`.
- Rename the displayed `Pause Duration` entity to `Pause Duration Water Plan`.
- Preserve their existing entity IDs and `unique_id` values.
- The naming makes clear that LinkTap's pause command suspends the water plan; it is not a conventional pause/resume control for the currently running watering session.

**Entity naming**
Set `has_entity_name = True` across `switch.py`, `valve.py`, `number.py`, `sensor.py` and `binary_sensor.py`.

Main switch and valve use `name = None`, allowing the Home Assistant device name to represent the primary entity.

Child entities expose relative names such as Battery, Signal, Watering Duration, Watering Volume, Pause Duration Water Plan, Is Watering, etc., instead of embedding `Linktap <tap name>` into every entity name.

Existing stable unique IDs are intentionally unchanged.

This allows Home Assistant to generate clean device-relative IDs when the user chooses to recreate them, for example:

switch.linktap_g2s01
valve.linktap_g2s01
switch.linktap_g2s01_pause
number.linktap_g2s01_watering_duration
number.linktap_g2s01_watering_volume
number.linktap_g2s01_pause_duration
sensor.linktap_g2s01_battery
sensor.linktap_g2s01_signal

The exact IDs remain controlled by Home Assistant's Entity ID format and can safely be renamed by the user after this fix.

**Reproduction before patch**

Debug logging from the affected Home Assistant instance showed the local gateway reporting:

Found devices: {'devs': ['...'], 'names': ['TapLinker']}

and then:

Entity number.linktap_taplinker_watering_duration not found -- setting default
Set duration:15
Entity number.linktap_taplinker_watering_volume not found -- setting default

**The actual Home Assistant duration entity had a device/area-based generated entity ID and therefore did not match the hard-coded lookup.**

**Validation**

Tested on a live Home Assistant installation with a replacement LinkTap G2S water timer.

**Entity-registry lookup and naming**
1. The Watering Duration entity ID was manually renamed without restarting Home Assistant.
2. The switch immediately resolved the renamed entity via its stable `unique_id`.
3. Watering Duration was set to 10 minutes and the LinkTap reported Total Duration = 600 seconds, confirming the configured duration was used rather than the 15-minute fallback.
4. The Home Assistant device was renamed to `Linktap G2S01` and the entity IDs were recreated using Home Assistant's current Entity ID format.
5. Watering duration continued to work correctly after recreation.
6. `valve.linktap_g2s01` successfully controlled the main LinkTap switch.
7. The water-plan pause control successfully resolved and used `number.linktap_g2s01_pause_duration`.

**Flow-rate metadata**
8. The LinkTap flow-rate sensor was verified with:
   - `device_class: volume_flow_rate`
   - `state_class: measurement`
   - canonical Home Assistant flow-rate units
9. The sensor became available for Home Assistant statistics and the Energy dashboard water flow-rate source.

**Unavailable-state handling**
10. Temporary `unknown` / `unavailable` number-helper states were tested and no longer raise numeric-conversion errors.
11. Watering duration, watering volume and pause duration continue to fall back safely when their helper state is temporarily invalid.

**Remaining-duration behaviour**
12. Before watering, `sensor.linktap_g2s01_remain_duration` reports `0`.
13. During watering, the sensor reports the gateway's remaining duration and counts down normally.
14. When watering is manually stopped before completion:
    - `binary_sensor.linktap_g2s01_is_watering` becomes `off`
    - `binary_sensor.linktap_g2s01_is_paused` becomes `off`
    - `sensor.linktap_g2s01_remain_duration` resets to `0`
15. This confirms the stale remaining-duration value previously retained by the gateway is no longer exposed as an active remaining time after watering stops.

**Diagnostic entities**
16. The following fault indicators were verified as appearing in Home Assistant's Diagnostic section:
    - fall
    - water cutoff
    - leaking
    - clogging
    - broken-device condition
17. Operational entities such as linked, manual mode, watering and paused remain normal device entities.

**Water-plan pause naming**
18. The displayed pause control was verified as `Pause Water Plan`.
19. The displayed pause-duration control was verified as `Pause Duration Water Plan`.
20. Their existing entity IDs and unique IDs remain unchanged.

The modified Python platform files also pass Python syntax compilation.

**What this fixes**

- New/current Home Assistant Entity ID formats no longer cause LinkTap to miss its Watering Duration entity and silently fall back to the default 15-minute watering duration.
- Watering Volume lookup is no longer dependent on the generated entity ID.
- Pause Duration lookup is no longer dependent on the generated entity ID.
- Valve control no longer depends on a guessed switch entity ID.
- Users can rename or recreate LinkTap entity IDs without breaking these internal relationships.
- Temporary `unknown` / `unavailable` helper states no longer cause numeric-conversion errors.
- The LinkTap flow-rate sensor now exposes proper Home Assistant flow-rate metadata, supports statistics, and can be used as the Energy dashboard water flow-rate source.
- `remain_duration` no longer displays a stale non-zero value after watering has stopped; it correctly returns to `0`.
- LinkTap fault indicators are grouped as Home Assistant diagnostic entities rather than ordinary operational entities.
- The existing LinkTap pause controls are named more clearly as `Pause Water Plan` and `Pause Duration Water Plan`, avoiding the impression that they provide a conventional pause/resume function for the currently running watering session.
- Entity names no longer unnecessarily repeat the manufacturer/tap name and integrate cleanly with Home Assistant's current device/entity naming model.
- Existing stable `unique_id` values are preserved, so the changes do not require an entity migration.

**Backward compatibility**

Existing unique_id values are preserved. Existing entity IDs are not automatically changed by this PR. Users who want the new cleaner IDs can use Home Assistant's entity-ID recreation functionality or rename entities manually.

Because sibling resolution now uses the Entity Registry and existing unique IDs, both old entity IDs and newly generated/renamed entity IDs remain valid.

**Documentation follow-up**

The README currently warns that renaming the duration entity can cause the integration to fall back to 15 minutes and advises users not to rename entities. That warning can be removed/updated once this fix is merged because entity-ID renaming is no longer part of the relationship logic.

**Related history**

Issue #63 / PR #64 addressed a similar symptom caused by differences in slugifying names containing umlauts. Switching to Home Assistant's slugify fixed that particular name conversion case, but the integration still depended on reconstructing the final entity ID. This PR removes that dependency entirely by resolving entities from their stable unique IDs.