### PR TITLE
Guard against repeated watering plan pause requests

### DIFF
--- a/custom_components/linktap/__init__.py
+++ b/custom_components/linktap/__init__.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 from h11 import Data
 from homeassistant import core
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.exceptions import IntegrationError
+from homeassistant.exceptions import HomeAssistantError, IntegrationError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.discovery import async_load_platform
@@ -117,9 +117,79 @@ class LinktapCoordinator(DataUpdateCoordinator):
         self.conf = conf
         self.hass = hass
         self.tap_id = tap_id
+        # Serialize all water-plan pause mutations for this tap. Without a lock,
+        # two HA callers could both observe an unpaused state and both send cmd 18.
+        self._pause_lock = asyncio.Lock()
 
     def get_gw_id(self):
         return self.conf[GW_ID]
+
+    async def async_set_water_plan_pause(self, hours):
+        """Safely set or clear this tap's watering-plan pause.
+
+        LinkTap issue #88 is destructive: a second positive cmd 18 while the
+        watering plan is already paused can deactivate the plan, even though
+        the gateway returns ret=0. Refresh immediately before the decision and
+        refuse repeated positive pause requests rather than risking plan loss.
+        """
+        hours = int(hours)
+        if hours < 0:
+            raise HomeAssistantError("Water plan pause duration cannot be negative")
+
+        async with self._pause_lock:
+            # Bypass the coordinator refresh debouncer: the safety decision must
+            # use a fresh gateway state, not a recently cached is_paused value.
+            await self.async_refresh()
+            if not self.last_update_success:
+                raise HomeAssistantError(
+                    "Unable to verify the current LinkTap water plan pause state; "
+                    "no pause command was sent."
+                )
+
+            is_paused = bool((self.data or {}).get("is_paused", False))
+
+            if hours > 0 and is_paused:
+                _LOGGER.warning(
+                    "Refusing repeated water plan pause for LinkTap %s: "
+                    "the plan is already paused and another positive pause "
+                    "request can deactivate the watering plan",
+                    self.tap_id,
+                )
+                raise HomeAssistantError(
+                    "Water plan is already paused. LinkTap cannot safely replace "
+                    "an active pause using the local API; the existing pause has "
+                    "been left unchanged."
+                )
+
+            if hours == 0 and not is_paused:
+                _LOGGER.debug(
+                    "Water plan for LinkTap %s is already unpaused; no command sent",
+                    self.tap_id,
+                )
+                return
+
+            gw_id = self.get_gw_id()
+            success = await self.tap_api.pause_tap(gw_id, self.tap_id, hours)
+            if not success:
+                raise HomeAssistantError(
+                    f"LinkTap gateway rejected water plan pause request for {self.tap_id}"
+                )
+
+            await self.async_refresh()
+            if not self.last_update_success:
+                raise HomeAssistantError(
+                    "LinkTap gateway accepted the water plan pause request, but "
+                    "Home Assistant could not verify the resulting gateway state."
+                )
+
+            expected_paused = hours > 0
+            actual_paused = bool((self.data or {}).get("is_paused", False))
+            if actual_paused != expected_paused:
+                action = "pause" if expected_paused else "unpause"
+                raise HomeAssistantError(
+                    f"LinkTap gateway accepted the {action} request but did not "
+                    "report the expected water plan pause state"
+                )
 
     #def get_vol_unit(self):
     #    return self.conf["vol_unit"]

--- a/custom_components/linktap/switch.py
+++ b/custom_components/linktap/switch.py
@@ -197,9 +197,7 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
         if hours is None:
             hours = 1
         _LOGGER.debug(f"Pausing {self.entity_id} for {hours} hours")
-        gw_id = self.coordinator.get_gw_id()
-        await self.tap_api.pause_tap(gw_id, self.tap_id, hours)
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_set_water_plan_pause(hours)
 
 
 class LinktapPauseSwitch(CoordinatorEntity, SwitchEntity):
@@ -268,15 +266,12 @@ class LinktapPauseSwitch(CoordinatorEntity, SwitchEntity):
                     f"PauseSwitch: Could not parse pause duration, using default 24: {e}"
                 )
         await self._pause_tap(hours=hours)
-        await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs):
         await self._pause_tap(hours=0)
-        await self.coordinator.async_request_refresh()
 
     async def _pause_tap(self, hours):
         _LOGGER.debug(
             f"Pause Water Plan: setting {self.entity_id} for {hours} hours"
         )
-        gw_id = self.coordinator.get_gw_id()
-        await self.coordinator.tap_api.pause_tap(gw_id, self.tap_id, hours)
+        await self.coordinator.async_set_water_plan_pause(hours)

--- a/custom_components/linktap/valve.py
+++ b/custom_components/linktap/valve.py
@@ -169,9 +169,7 @@ class LinktapValve(CoordinatorEntity, ValveEntity):
         if hours is None:
             hours = 1
         _LOGGER.debug(f"Pausing {self.entity_id} for {hours} hours")
-        gw_id = self.coordinator.get_gw_id()
-        await self.coordinator.tap_api.pause_tap(gw_id, self.tap_id, hours)
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_set_water_plan_pause(hours)
 
     async def _start_watering(self, seconds=False):
         if not seconds or seconds == 0:


### PR DESCRIPTION
## Summary

This prevents a destructive repeated watering-plan pause request from reaching the LinkTap local API when the tap is already paused.

Issue #88 reports that sending another pause while a watering plan is already paused can deactivate the plan. Live debug testing confirms the gateway still returns `ret: 0` for that destructive second `cmd 18`, so the response code cannot be used to detect the failure after the fact.

## Approach

- Centralise watering-plan pause/unpause mutations in the per-tap coordinator.
- Serialize pause mutations with an `asyncio.Lock` so concurrent HA callers cannot both observe an unpaused state and send duplicate positive pause commands.
- Force a fresh gateway refresh before deciding whether a positive pause is safe.
- If the gateway already reports `is_paused: true`, reject another positive pause with a clear `HomeAssistantError` and leave the existing pause unchanged.
- Treat an unpause request while already unpaused as an idempotent no-op.
- Refresh and verify the resulting `is_paused` state after an allowed pause/unpause command.
- Route the main switch `pause` service, the `Pause Water Plan` switch, and the valve `pause_valve` service through the same coordinator guard.

The underlying local API payload and `cmd 18` implementation are intentionally unchanged; this does not introduce undocumented protocol fields or attempt an unsafe `pause 0 -> pause N` sequence.

## Live validation

Tested on a LinkTap G2S against the current v0.8.1 codebase.

- Normal 1-hour pause succeeds.
- Repeated `linktap.pause` with `hours: 2` while paused is (correctly now) rejected by Home Assistant.
- Repeated `linktap.pause_valve` with `hours: 2` while paused is (correctly now) rejected by Home Assistant.
- Debug logging confirms no `Pause Payload` with `duration: 2` reaches the gateway during this guarded test.
- The existing pause remains active after the rejected request.
- Normal unpause restores the original 7-Day watering plan and the same `plan_sn`.
- After reloading the integration while paused, the newly-created coordinator rediscovers `is_paused: true` from the gateway and still blocks the repeated positive pause, so the protection does not depend on remembered in-memory state.

## Limitation

This deliberately does **not** update the expiry of an already-active plan pause. The local API behaviour observed in #88 makes a second positive pause unsafe, and no documented local-API overwrite/replace operation is currently known. Until such an operation is identified, preserving the existing pause is safer than risking deletion of the watering plan.

Addresses #88.