### PR TITLE
Add configurable per-device instant watering safety limits

### DIFF
--- a/custom_components/linktap/config_flow.py
+++ b/custom_components/linktap/config_flow.py
@@ -12,18 +12,10 @@ from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import selector
 
-from .const import (
-    CONF_MAX_WATERING_DURATION,
-    CONF_MAX_WATERING_VOLUME,
-    CONF_WATERING_SAFETY_LIMITS,
-    DEFAULT_NAME,
-    DOMAIN,
-    GW_IP,
-    NAME,
-    NATIVE_MAX_WATERING_DURATION,
-    NATIVE_MAX_WATERING_VOLUME,
-    TAP_ID,
-)
+from .const import (CONF_MAX_WATERING_DURATION, CONF_MAX_WATERING_VOLUME,
+                    CONF_WATERING_SAFETY_LIMITS, DEFAULT_NAME, DOMAIN, GW_IP,
+                    NAME, NATIVE_MAX_WATERING_DURATION,
+                    NATIVE_MAX_WATERING_VOLUME, TAP_ID)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/linktap/config_flow.py
+++ b/custom_components/linktap/config_flow.py
@@ -3,25 +3,44 @@ from __future__ import annotations
 
 import logging
 import secrets
+from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry, OptionsFlow
+from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import selector
 
-from .const import DEFAULT_NAME, DOMAIN, GW_ID, GW_IP, NAME, TAP_ID
+from .const import (
+    CONF_MAX_WATERING_DURATION,
+    CONF_MAX_WATERING_VOLUME,
+    CONF_WATERING_SAFETY_LIMITS,
+    DEFAULT_NAME,
+    DOMAIN,
+    GW_IP,
+    NAME,
+    NATIVE_MAX_WATERING_DURATION,
+    NATIVE_MAX_WATERING_VOLUME,
+    TAP_ID,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
+
 @config_entries.HANDLERS.register(DOMAIN)
 class LinktapFlowHandler(config_entries.ConfigFlow):
-
     VERSION = 1
-    def __init__(self):
-        super().__init__()
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry):
+        """Create the LinkTap options flow."""
+        return LinktapOptionsFlowHandler()
 
     async def async_step_user(self, user_input=None):
         """Handle a flow start."""
         _LOGGER.debug(f"Starting async_step_user of {DEFAULT_NAME}")
-
         errors = None
 
         if user_input is not None:
@@ -29,10 +48,149 @@ class LinktapFlowHandler(config_entries.ConfigFlow):
             self._abort_if_unique_id_configured()
             return self.async_create_entry(title=DEFAULT_NAME, data=user_input)
 
-        new_user_input = {
-            vol.Required(GW_IP, default=GW_IP): str,
-        }
-
-        schema = vol.Schema(new_user_input)
-
+        schema = vol.Schema({vol.Required(GW_IP, default=GW_IP): str})
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+
+class LinktapOptionsFlowHandler(OptionsFlow):
+    """Configure optional per-device instant-watering safety ceilings.
+
+    The integration already registers a ConfigEntry update listener in __init__.py
+    which reloads the entry after options change. Use plain OptionsFlow here so
+    the same change is not also reloaded by OptionsFlowWithReload.
+    """
+
+    def __init__(self) -> None:
+        self._tap_id: str | None = None
+        self._tap_name: str | None = None
+
+    def _entry_conf(self) -> dict[str, Any]:
+        """Return the loaded runtime configuration for this config entry."""
+        entry_data = self.hass.data.get(DOMAIN, {}).get(
+            self.config_entry.entry_id, {}
+        )
+        return entry_data.get("conf", {})
+
+    def _taps(self) -> list[dict[str, Any]]:
+        """Return taps currently loaded for this config entry."""
+        return self._entry_conf().get("taps", [])
+
+    def _volume_unit(self) -> str:
+        """Return the gateway's configured native volume unit."""
+        return self._entry_conf().get("vol_unit", "L")
+
+    def _ha_device_name(self, tap: dict[str, Any]) -> str:
+        """Return the Home Assistant device name, falling back to gateway name."""
+        device = dr.async_get(self.hass).async_get_device(
+            identifiers={(DOMAIN, tap[TAP_ID])}
+        )
+        if device is not None:
+            return device.name_by_user or device.name or tap[NAME]
+        return tap[NAME]
+
+    async def async_step_init(self, user_input=None):
+        """Choose a tap when needed, then configure its limits."""
+        taps = self._taps()
+        if not taps:
+            return self.async_abort(reason="integration_not_loaded")
+
+        if len(taps) == 1:
+            self._tap_id = taps[0][TAP_ID]
+            self._tap_name = self._ha_device_name(taps[0])
+            return await self.async_step_limits()
+
+        if user_input is not None:
+            self._tap_id = user_input["tap_id"]
+            selected = next(
+                (tap for tap in taps if tap[TAP_ID] == self._tap_id),
+                None,
+            )
+            if selected is None:
+                return self.async_abort(reason="tap_not_found")
+            self._tap_name = self._ha_device_name(selected)
+            return await self.async_step_limits()
+
+        options = [
+            selector.SelectOptionDict(
+                value=tap[TAP_ID],
+                label=self._ha_device_name(tap),
+            )
+            for tap in taps
+        ]
+        schema = vol.Schema(
+            {
+                vol.Required("tap_id"): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=options,
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                )
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=schema)
+
+    async def async_step_limits(self, user_input=None):
+        """Configure independent optional safety ceilings for one tap."""
+        if self._tap_id is None:
+            return await self.async_step_init()
+
+        all_limits = dict(
+            self.config_entry.options.get(CONF_WATERING_SAFETY_LIMITS, {})
+        )
+        current = dict(all_limits.get(self._tap_id, {}))
+
+        if user_input is not None:
+            updated = {}
+            if CONF_MAX_WATERING_DURATION in user_input:
+                updated[CONF_MAX_WATERING_DURATION] = int(
+                    user_input[CONF_MAX_WATERING_DURATION]
+                )
+            if CONF_MAX_WATERING_VOLUME in user_input:
+                updated[CONF_MAX_WATERING_VOLUME] = int(
+                    user_input[CONF_MAX_WATERING_VOLUME]
+                )
+
+            if updated:
+                all_limits[self._tap_id] = updated
+            else:
+                all_limits.pop(self._tap_id, None)
+
+            new_options = dict(self.config_entry.options)
+            if all_limits:
+                new_options[CONF_WATERING_SAFETY_LIMITS] = all_limits
+            else:
+                new_options.pop(CONF_WATERING_SAFETY_LIMITS, None)
+
+            # Existing integration update listener reloads the entry.
+            return self.async_create_entry(data=new_options)
+
+        schema = vol.Schema(
+            {
+                vol.Optional(CONF_MAX_WATERING_DURATION): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=5,
+                        max=NATIVE_MAX_WATERING_DURATION,
+                        step=5,
+                        mode=selector.NumberSelectorMode.BOX,
+                        unit_of_measurement="min",
+                    )
+                ),
+                vol.Optional(CONF_MAX_WATERING_VOLUME): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=10,
+                        max=NATIVE_MAX_WATERING_VOLUME,
+                        step=10,
+                        mode=selector.NumberSelectorMode.BOX,
+                        unit_of_measurement=self._volume_unit(),
+                    )
+                ),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="limits",
+            data_schema=self.add_suggested_values_to_schema(schema, current),
+            description_placeholders={
+                "tap_name": self._tap_name or self._tap_id,
+            },
+        )

--- a/custom_components/linktap/const.py
+++ b/custom_components/linktap/const.py
@@ -19,3 +19,15 @@ ATTR_DURATION = "Watering Duration"
 ATTR_VOLUME = "Watering Volume"
 ATTR_STATE = "is_watering"
 MANUFACTURER = "Linktap"
+
+# Optional per-device Home Assistant safety ceilings for instant watering.
+# These do not alter LinkTap's own limits; they constrain requests made by
+# this Home Assistant integration.
+CONF_WATERING_SAFETY_LIMITS = "watering_safety_limits"
+CONF_MAX_WATERING_DURATION = "max_watering_duration"
+CONF_MAX_WATERING_VOLUME = "max_watering_volume"
+
+# Existing integration/native entity maxima. Leaving an option unset preserves
+# these existing limits and therefore preserves current behaviour.
+NATIVE_MAX_WATERING_DURATION = 120
+NATIVE_MAX_WATERING_VOLUME = 2000

--- a/custom_components/linktap/number.py
+++ b/custom_components/linktap/number.py
@@ -12,21 +12,11 @@ from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
-from .const import (
-    CONF_MAX_WATERING_DURATION,
-    CONF_MAX_WATERING_VOLUME,
-    CONF_WATERING_SAFETY_LIMITS,
-    DEFAULT_TIME,
-    DEFAULT_VOL,
-    DOMAIN,
-    GW_ID,
-    GW_IP,
-    MANUFACTURER,
-    NAME,
-    NATIVE_MAX_WATERING_DURATION,
-    NATIVE_MAX_WATERING_VOLUME,
-    TAP_ID,
-)
+from .const import (CONF_MAX_WATERING_DURATION, CONF_MAX_WATERING_VOLUME,
+                    CONF_WATERING_SAFETY_LIMITS, DEFAULT_TIME, DEFAULT_VOL,
+                    DOMAIN, GW_ID, GW_IP, MANUFACTURER, NAME,
+                    NATIVE_MAX_WATERING_DURATION, NATIVE_MAX_WATERING_VOLUME,
+                    TAP_ID)
 
 
 def _safety_limits(config, tap_id):

--- a/custom_components/linktap/number.py
+++ b/custom_components/linktap/number.py
@@ -12,74 +12,115 @@ from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
-from .const import (DEFAULT_TIME, DEFAULT_VOL, DOMAIN, GW_ID, GW_IP,
-                    MANUFACTURER, NAME, TAP_ID)
+from .const import (
+    CONF_MAX_WATERING_DURATION,
+    CONF_MAX_WATERING_VOLUME,
+    CONF_WATERING_SAFETY_LIMITS,
+    DEFAULT_TIME,
+    DEFAULT_VOL,
+    DOMAIN,
+    GW_ID,
+    GW_IP,
+    MANUFACTURER,
+    NAME,
+    NATIVE_MAX_WATERING_DURATION,
+    NATIVE_MAX_WATERING_VOLUME,
+    TAP_ID,
+)
 
 
-async def async_setup_entry(
-    hass, config, async_add_entities, discovery_info=None
-):
+def _safety_limits(config, tap_id):
+    return config.options.get(CONF_WATERING_SAFETY_LIMITS, {}).get(tap_id, {})
+
+
+async def async_setup_entry(hass, config, async_add_entities, discovery_info=None):
     """Setup the number platform."""
     taps = hass.data[DOMAIN][config.entry_id]["conf"]["taps"]
     numbers = []
     for tap in taps:
-        """For each tap, we set a number for duration, volume, and water-plan pause duration"""
-        _LOGGER.debug(f"Configuring numbers for tap {tap}")
         coordinator = tap["coordinator"]
-        numbers.append(LinktapNumber(coordinator, hass, tap, "Watering duration", "mdi:clock", "m"))
-        numbers.append(LinktapNumber(coordinator, hass, tap, "Watering volume", "mdi:water", hass.data[DOMAIN][config.entry_id]["conf"]["vol_unit"]))
-        numbers.append(LinktapPauseDurationNumber(coordinator, hass, tap, "Pause Duration Water Plan", "mdi:timer-pause", "h"))
-
+        limits = _safety_limits(config, tap[TAP_ID])
+        numbers.append(
+            LinktapNumber(
+                coordinator, hass, tap, "Watering duration", "mdi:clock", "m",
+                safety_max=limits.get(CONF_MAX_WATERING_DURATION),
+            )
+        )
+        numbers.append(
+            LinktapNumber(
+                coordinator, hass, tap, "Watering volume", "mdi:water",
+                hass.data[DOMAIN][config.entry_id]["conf"]["vol_unit"],
+                safety_max=limits.get(CONF_MAX_WATERING_VOLUME),
+            )
+        )
+        numbers.append(
+            LinktapPauseDurationNumber(
+                coordinator, hass, tap, "Pause Duration Water Plan",
+                "mdi:timer-pause", "h"
+            )
+        )
     async_add_entities(numbers, True)
 
 
 class LinktapNumber(CoordinatorEntity, RestoreNumber):
-    # Modern HA naming: entity name is relative to the device name.
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator: DataUpdateCoordinator, hass, tap, number_suffix, icon, unit_of_measurement):
+    def __init__(
+        self, coordinator: DataUpdateCoordinator, hass, tap, number_suffix,
+        icon, unit_of_measurement, safety_max=None
+    ):
         super().__init__(coordinator)
         self._state = None
         self._name = tap[NAME]
         self._id = self._name
         self.tap_id = tap[TAP_ID]
         self.platform = "number"
-        # IMPORTANT: keep unique_id formula unchanged for registry/history stability.
-        self._attr_unique_id = slugify(f"{DOMAIN}_{self.platform}_{self.tap_id}_{number_suffix.replace(' ', '_')}")
+        self._attr_unique_id = slugify(
+            f"{DOMAIN}_{self.platform}_{self.tap_id}_{number_suffix.replace(' ', '_')}"
+        )
         self._attr_name = number_suffix
         self._attr_native_min_value = 0
-        self._attr_native_max_value = 120
+        self._attr_native_max_value = NATIVE_MAX_WATERING_DURATION
         self._attr_native_step = 5
+
         if number_suffix == "Watering volume":
-            self._attr_native_max_value = 2000
+            self._attr_native_max_value = NATIVE_MAX_WATERING_VOLUME
             self._attr_native_step = 10
+
+        if safety_max is not None:
+            self._attr_native_max_value = min(
+                float(safety_max), self._attr_native_max_value
+            )
+
         self._attr_native_unit_of_measurement = unit_of_measurement
         self._attr_icon = icon
         self.number_suffix = number_suffix
         self._attr_device_info = DeviceInfo(
-            identifiers={
-                (DOMAIN, tap[TAP_ID])
-            },
+            identifiers={(DOMAIN, tap[TAP_ID])},
             name=tap[NAME],
             manufacturer=MANUFACTURER,
             model=tap[TAP_ID],
-            configuration_url="http://" + tap[GW_IP] + "/"
+            configuration_url="http://" + tap[GW_IP] + "/",
         )
-
         self._attrs = {}
+        if safety_max is not None:
+            self._attrs["safety_maximum"] = self._attr_native_max_value
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
         restored_number = await self.async_get_last_number_data()
         if restored_number is not None and restored_number.native_value != STATE_UNKNOWN:
-            _LOGGER.debug(f"Restoring value to {restored_number.native_value}")
-            self._attr_native_value = restored_number.native_value
+            restored = float(restored_number.native_value)
+            restored = max(
+                self._attr_native_min_value,
+                min(restored, self._attr_native_max_value),
+            )
+            _LOGGER.debug(f"Restoring value to {restored}")
+            self._attr_native_value = restored
         else:
             _LOGGER.debug("No value found to restore -- setting default")
-            if self.number_suffix == "Watering volume":
-                self._attr_native_value = DEFAULT_VOL
-            else:
-                self._attr_native_value = DEFAULT_TIME
+            default_value = DEFAULT_VOL if self.number_suffix == "Watering volume" else DEFAULT_TIME
+            self._attr_native_value = min(default_value, self._attr_native_max_value)
         self.async_write_ha_state()
 
     @property
@@ -95,14 +136,16 @@ class LinktapNumber(CoordinatorEntity, RestoreNumber):
         return self._attr_device_info
 
     async def async_set_native_value(self, value: float) -> None:
-        """Update the current value."""
+        value = max(
+            self._attr_native_min_value,
+            min(float(value), self._attr_native_max_value),
+        )
         self._attr_native_value = value
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
 
 class LinktapPauseDurationNumber(CoordinatorEntity, RestoreNumber):
-    # Modern HA naming: entity name is relative to the device name.
     _attr_has_entity_name = True
 
     def __init__(self, coordinator: DataUpdateCoordinator, hass, tap, number_suffix, icon, unit_of_measurement):
@@ -111,14 +154,9 @@ class LinktapPauseDurationNumber(CoordinatorEntity, RestoreNumber):
         self._name = tap[NAME]
         self.tap_id = tap[TAP_ID]
         self.platform = "number"
-
-        # IMPORTANT: unique_id is intentionally unchanged. Although the displayed
-        # name is now "Pause Duration Water Plan", registry/history must remain
-        # tied to the existing pause_duration entity.
         self._attr_unique_id = slugify(
             f"{DOMAIN}_{self.platform}_{self.tap_id}_pause_duration"
         )
-
         self._attr_name = number_suffix
         self._attr_native_min_value = 1
         self._attr_native_max_value = 240
@@ -127,13 +165,11 @@ class LinktapPauseDurationNumber(CoordinatorEntity, RestoreNumber):
         self._attr_icon = icon
         self.number_suffix = number_suffix
         self._attr_device_info = DeviceInfo(
-            identifiers={
-                (DOMAIN, tap[TAP_ID])
-            },
+            identifiers={(DOMAIN, tap[TAP_ID])},
             name=tap[NAME],
             manufacturer=MANUFACTURER,
             model=tap[TAP_ID],
-            configuration_url="http://" + tap[GW_IP] + "/"
+            configuration_url="http://" + tap[GW_IP] + "/",
         )
         self._attrs = {}
 

--- a/custom_components/linktap/strings.json
+++ b/custom_components/linktap/strings.json
@@ -1,0 +1,29 @@
+{
+  "options": {
+    "step": {
+      "init": {
+        "title": "Select LinkTap watering device",
+        "description": "Choose the LinkTap watering device whose optional instant-watering safety limits you want to configure.",
+        "data": {
+          "tap_id": "LinkTap watering device"
+        }
+      },
+      "limits": {
+        "title": "Instant watering safety limits — {tap_name}",
+        "description": "These optional Home Assistant safety limits apply to this LinkTap device only. Each installed LinkTap watering device is configured separately. They limit instant-watering requests made by Home Assistant and do not change LinkTap firmware limits. Leave either field blank to keep the integration's existing maximum for that control.",
+        "data": {
+          "max_watering_duration": "Maximum instant watering duration",
+          "max_watering_volume": "Maximum instant watering volume"
+        },
+        "data_description": {
+          "max_watering_duration": "Optional. Maximum duration Home Assistant may request for an instant watering session on this device.",
+          "max_watering_volume": "Optional. Maximum non-zero volume Home Assistant may request for an instant watering session on this device. A Watering Volume value of 0 still disables that session's volume cutoff."
+        }
+      }
+    },
+    "abort": {
+      "integration_not_loaded": "The LinkTap integration must be loaded before safety limits can be configured.",
+      "tap_not_found": "The selected LinkTap watering device could not be found."
+    }
+  }
+}

--- a/custom_components/linktap/switch.py
+++ b/custom_components/linktap/switch.py
@@ -22,9 +22,24 @@ from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
-from .const import (ATTR_DEFAULT_TIME, ATTR_DURATION, ATTR_STATE, ATTR_VOL,
-                    ATTR_VOLUME, DEFAULT_TIME, DEFAULT_VOL, DOMAIN, GW_ID,
-                    GW_IP, MANUFACTURER, NAME, TAP_ID)
+from .const import (
+    ATTR_DEFAULT_TIME,
+    ATTR_DURATION,
+    ATTR_STATE,
+    ATTR_VOL,
+    ATTR_VOLUME,
+    CONF_MAX_WATERING_DURATION,
+    CONF_MAX_WATERING_VOLUME,
+    CONF_WATERING_SAFETY_LIMITS,
+    DEFAULT_TIME,
+    DEFAULT_VOL,
+    DOMAIN,
+    GW_ID,
+    GW_IP,
+    MANUFACTURER,
+    NAME,
+    TAP_ID,
+)
 
 
 def _number_entity_id(hass, tap_id, suffix):
@@ -40,32 +55,49 @@ def _number_entity_id(hass, tap_id, suffix):
     )
 
 
-async def async_setup_entry(
-    hass, config, async_add_entities, discovery_info=None
-):
+def _safety_limits(config, tap_id):
+    return config.options.get(CONF_WATERING_SAFETY_LIMITS, {}).get(tap_id, {})
+
+
+async def async_setup_entry(hass, config, async_add_entities, discovery_info=None):
     """Setup the switch platform."""
     taps = hass.data[DOMAIN][config.entry_id]["conf"]["taps"]
     switches = []
     for tap in taps:
         coordinator = tap["coordinator"]
-        _LOGGER.debug(f"Configuring switch for tap {tap}")
-        switches.append(LinktapSwitch(coordinator, hass, tap))
+        limits = _safety_limits(config, tap[TAP_ID])
+        switches.append(
+            LinktapSwitch(
+                coordinator,
+                hass,
+                tap,
+                max_watering_duration=limits.get(CONF_MAX_WATERING_DURATION),
+                max_watering_volume=limits.get(CONF_MAX_WATERING_VOLUME),
+            )
+        )
         switches.append(LinktapPauseSwitch(coordinator, hass, tap))
     async_add_entities(switches, True)
 
     platform = entity_platform.async_get_current_platform()
-    platform.async_register_entity_service("pause",
+    platform.async_register_entity_service(
+        "pause",
         {vol.Required("hours", default=1): vol.Coerce(int)},
-        "_pause_tap"
-        )
+        "_pause_tap",
+    )
 
 
 class LinktapSwitch(CoordinatorEntity, SwitchEntity):
-    # Modern HA naming: this is a main feature of the device.
     _attr_has_entity_name = True
     _attr_name = None
 
-    def __init__(self, coordinator: DataUpdateCoordinator, hass, tap):
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        hass,
+        tap,
+        max_watering_duration=None,
+        max_watering_volume=None,
+    ):
         super().__init__(coordinator)
         self._state = None
         self._name = tap[NAME]
@@ -74,18 +106,28 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
         self.tap_api = coordinator.tap_api
         self.platform = "switch"
         self.hass = hass
+        self.max_watering_duration = (
+            float(max_watering_duration)
+            if max_watering_duration is not None
+            else None
+        )
+        self.max_watering_volume = (
+            float(max_watering_volume)
+            if max_watering_volume is not None
+            else None
+        )
         self._attr_unique_id = slugify(f"{DOMAIN}_{self.platform}_{self.tap_id}")
         self._attr_icon = "mdi:water-pump"
-        self._attrs = {
-            "data": self.coordinator.data,
-        }
+        self._attrs = {"data": self.coordinator.data}
+        if self.max_watering_duration is not None:
+            self._attrs["max_watering_duration_safety"] = self.max_watering_duration
+        if self.max_watering_volume is not None:
+            self._attrs["max_watering_volume_safety"] = self.max_watering_volume
         self._attr_device_info = DeviceInfo(
-            identifiers={
-                (DOMAIN, tap[TAP_ID])
-            },
+            identifiers={(DOMAIN, tap[TAP_ID])},
             name=tap[NAME],
             manufacturer=MANUFACTURER,
-            configuration_url="http://" + tap[GW_IP] + "/"
+            configuration_url="http://" + tap[GW_IP] + "/",
         )
 
     @property
@@ -104,34 +146,32 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
         duration = self.get_watering_duration()
         seconds = int(float(duration)) * 60
         gw_id = self.coordinator.get_gw_id()
-        attributes = await self.tap_api.turn_on(
+        await self.tap_api.turn_on(
             gw_id, self.tap_id, seconds, self.get_watering_volume()
         )
         await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs):
         gw_id = self.coordinator.get_gw_id()
-        attributes = await self.tap_api.turn_off(gw_id, self.tap_id)
+        await self.tap_api.turn_off(gw_id, self.tap_id)
         await self.coordinator.async_request_refresh()
 
     def get_watering_duration(self):
         entity_id = self.duration_entity
         entity = self.hass.states.get(entity_id) if entity_id else None
         if not entity:
-            _LOGGER.debug(
-                "Watering duration entity could not be resolved -- setting default"
-            )
-            duration = DEFAULT_TIME
+            duration = float(DEFAULT_TIME)
             self._attrs[ATTR_DEFAULT_TIME] = True
         elif entity.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
-            _LOGGER.debug(
-                f"Entity {entity_id} state {entity.state} -- setting default"
-            )
-            duration = DEFAULT_TIME
+            duration = float(DEFAULT_TIME)
             self._attrs[ATTR_DEFAULT_TIME] = True
         else:
-            duration = entity.state
+            duration = float(entity.state)
             self._attrs[ATTR_DEFAULT_TIME] = False
+
+        if self.max_watering_duration is not None:
+            duration = min(duration, self.max_watering_duration)
+
         self._attrs[ATTR_DURATION] = duration
         return duration
 
@@ -139,30 +179,23 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
         entity_id = self.volume_entity
         entity = self.hass.states.get(entity_id) if entity_id else None
         if not entity:
-            volume = DEFAULT_VOL
-            _LOGGER.debug(
-                "Watering volume entity could not be resolved -- setting default"
-            )
+            volume = float(DEFAULT_VOL)
             self._attrs[ATTR_VOL] = False
         elif entity.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
-            volume = DEFAULT_VOL
-            _LOGGER.debug(
-                f"Entity {entity_id} state {entity.state} -- setting default"
-            )
-            self._attrs[ATTR_VOL] = False
-        elif int(float(entity.state)) == 0:
-            volume = entity.state
-            _LOGGER.debug(f"Entity {entity_id} set to 0 -- ignore")
+            volume = float(DEFAULT_VOL)
             self._attrs[ATTR_VOL] = False
         else:
-            volume = entity.state
-            self._attrs[ATTR_VOL] = True
+            volume = float(entity.state)
+            self._attrs[ATTR_VOL] = volume != 0
+
+        if volume > 0 and self.max_watering_volume is not None:
+            volume = min(volume, self.max_watering_volume)
+
         self._attrs[ATTR_VOLUME] = volume
-        return float(volume)
+        return volume
 
     @property
     def extra_state_attributes(self):
-        # Resolve dynamically so HA/user entity-id renames are followed.
         self._attrs["duration_entity"] = self.duration_entity
         self._attrs["volume_entity"] = self.volume_entity
         return self._attrs
@@ -171,18 +204,14 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
     def state(self):
         status = self.coordinator.data
         self._attrs["data"] = status
-        _LOGGER.debug(f"Switch Status: {status}")
         duration = self.get_watering_duration()
-        _LOGGER.debug(f"Set duration:{duration}")
         volume = self.get_watering_volume()
-        _LOGGER.debug(f"Set volume:{volume}")
         self._attrs[ATTR_STATE] = status[ATTR_STATE]
         state = "unknown"
         if status[ATTR_STATE]:
             state = "on"
         elif not status[ATTR_STATE]:
             state = "off"
-            _LOGGER.debug(f"Switch {self.entity_id} state {state}")
         return state
 
     @property
@@ -196,13 +225,10 @@ class LinktapSwitch(CoordinatorEntity, SwitchEntity):
     async def _pause_tap(self, hours=None):
         if hours is None:
             hours = 1
-        _LOGGER.debug(f"Pausing {self.entity_id} for {hours} hours")
         await self.coordinator.async_set_water_plan_pause(hours)
 
 
 class LinktapPauseSwitch(CoordinatorEntity, SwitchEntity):
-    # Modern HA naming: this controls LinkTap's watering-plan suspension,
-    # not pause/resume of the current watering session.
     _attr_has_entity_name = True
     _attr_name = "Pause Water Plan"
 
@@ -213,20 +239,15 @@ class LinktapPauseSwitch(CoordinatorEntity, SwitchEntity):
         self.tap_id = tap[TAP_ID]
         self.platform = "switch"
         self.hass = hass
-
-        # IMPORTANT: unique_id is intentionally unchanged so existing entity
-        # registry/history remains attached to the same entity.
         self._attr_unique_id = slugify(
             f"{DOMAIN}_{self.platform}_{self.tap_id}_pause"
         )
         self._attr_icon = "mdi:pause-circle"
         self._attr_device_info = DeviceInfo(
-            identifiers={
-                (DOMAIN, tap[TAP_ID])
-            },
+            identifiers={(DOMAIN, tap[TAP_ID])},
             name=tap[NAME],
             manufacturer=MANUFACTURER,
-            configuration_url="http://" + tap[GW_IP] + "/"
+            configuration_url="http://" + tap[GW_IP] + "/",
         )
         self.coordinator = coordinator
         self._attrs = {}
@@ -252,26 +273,16 @@ class LinktapPauseSwitch(CoordinatorEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs):
         hours = 24
         entity_id = self.pause_duration_entity
-        _LOGGER.debug(f"PauseSwitch: Looking for {entity_id}")
         entity = self.hass.states.get(entity_id) if entity_id else None
         if entity and entity.state not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
-            _LOGGER.debug(
-                f"PauseSwitch: Found pause duration entity {entity_id} "
-                f"with state {entity.state}"
-            )
             try:
                 hours = int(float(entity.state))
-            except Exception as e:
-                _LOGGER.warning(
-                    f"PauseSwitch: Could not parse pause duration, using default 24: {e}"
-                )
+            except Exception:
+                hours = 24
         await self._pause_tap(hours=hours)
 
     async def async_turn_off(self, **kwargs):
         await self._pause_tap(hours=0)
 
     async def _pause_tap(self, hours):
-        _LOGGER.debug(
-            f"Pause Water Plan: setting {self.entity_id} for {hours} hours"
-        )
         await self.coordinator.async_set_water_plan_pause(hours)

--- a/custom_components/linktap/switch.py
+++ b/custom_components/linktap/switch.py
@@ -22,24 +22,11 @@ from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
-from .const import (
-    ATTR_DEFAULT_TIME,
-    ATTR_DURATION,
-    ATTR_STATE,
-    ATTR_VOL,
-    ATTR_VOLUME,
-    CONF_MAX_WATERING_DURATION,
-    CONF_MAX_WATERING_VOLUME,
-    CONF_WATERING_SAFETY_LIMITS,
-    DEFAULT_TIME,
-    DEFAULT_VOL,
-    DOMAIN,
-    GW_ID,
-    GW_IP,
-    MANUFACTURER,
-    NAME,
-    TAP_ID,
-)
+from .const import (ATTR_DEFAULT_TIME, ATTR_DURATION, ATTR_STATE, ATTR_VOL,
+                    ATTR_VOLUME, CONF_MAX_WATERING_DURATION,
+                    CONF_MAX_WATERING_VOLUME, CONF_WATERING_SAFETY_LIMITS,
+                    DEFAULT_TIME, DEFAULT_VOL, DOMAIN, GW_ID, GW_IP,
+                    MANUFACTURER, NAME, TAP_ID)
 
 
 def _number_entity_id(hass, tap_id, suffix):

--- a/custom_components/linktap/translations/en.json
+++ b/custom_components/linktap/translations/en.json
@@ -1,0 +1,29 @@
+{
+  "options": {
+    "step": {
+      "init": {
+        "title": "Select LinkTap watering device",
+        "description": "Choose the LinkTap watering device whose optional instant-watering safety limits you want to configure.",
+        "data": {
+          "tap_id": "LinkTap watering device"
+        }
+      },
+      "limits": {
+        "title": "Instant watering safety limits — {tap_name}",
+        "description": "These optional Home Assistant safety limits apply to this LinkTap device only. Each installed LinkTap watering device is configured separately. They limit instant-watering requests made by Home Assistant and do not change LinkTap firmware limits. Leave either field blank to keep the integration's existing maximum for that control.",
+        "data": {
+          "max_watering_duration": "Maximum instant watering duration",
+          "max_watering_volume": "Maximum instant watering volume"
+        },
+        "data_description": {
+          "max_watering_duration": "Optional. Maximum duration Home Assistant may request for an instant watering session on this device.",
+          "max_watering_volume": "Optional. Maximum non-zero volume Home Assistant may request for an instant watering session on this device. A Watering Volume value of 0 still disables that session's volume cutoff."
+        }
+      }
+    },
+    "abort": {
+      "integration_not_loaded": "The LinkTap integration must be loaded before safety limits can be configured.",
+      "tap_not_found": "The selected LinkTap watering device could not be found."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds optional per-device Home Assistant safety ceilings for instant watering duration and volume.

These limits are deliberately HA-side controls only: they do not change LinkTap firmware/device limits and they only affect instant watering started through this integration.

## Why

LinkTap device capabilities vary significantly, so a single hard-coded physical/session limit is not appropriate across all supported hardware. This provides a configurable per-device guard instead of embedding universal assumptions.

## Changes

- add LinkTap Options flow for per-device instant-watering safety limits
- support optional maximum watering duration and maximum watering volume per tap
- use the gateway's configured volume unit in the options UI
- cap the existing duration/volume number entities to the configured safety maximum
- clamp restored/default number values to the effective range
- enforce the same limits again at the switch command boundary before sending `turn_on`
- preserve `0` volume semantics (`0` still means no volume cutoff)
- expose configured limits as state attributes on the watering switch/number entities
- preserve the v0.8.2 pause handling path through `coordinator.async_set_water_plan_pause()`

## Compatibility / scope

- unset options preserve existing behaviour
- no entity ID or unique ID migration
- no changes to `sensor.py`, including the Volume Total accumulator/guard work
- no changes to the coordinator pause-guard implementation from #96
- intended as a separate follow-up from #95/#96

## Live testing

Tested on a G2S with Home Assistant after rebasing onto current upstream `main` / v0.8.2.

Verified:

- integration loads cleanly and existing entities remain intact
- Options UI appears correctly for the active device and reports litres from the gateway
- configured limits of 30 min / 200 L persist
- duration number entity exposes `max: 30` and `safety_maximum: 30`
- volume number entity exposes `max: 200`, unit `L`, and `safety_maximum: 200`
- direct `number.set_value` attempt of 60 min is rejected as outside the 0–30 range
- real HA instant watering at 5 min / 0 L starts correctly (`total_duration: 300`, `volume_limit: 0`)
- watering switch exposes the configured safety-limit attributes while running

## Design note

The command path intentionally applies the configured ceiling again even though the number entities are already constrained. That gives a defensive final guard immediately before the LinkTap `turn_on` request in case an unexpected/stale entity value reaches the switch logic.