### PR TITLE
Validate LinkTap gateway IPv4 address during config flow

### DIFF
--- a/custom_components/linktap/config_flow.py
+++ b/custom_components/linktap/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow to configure."""
 from __future__ import annotations
 
+import ipaddress
 import logging
 import secrets
 from typing import Any
@@ -20,6 +21,19 @@ from .const import (CONF_MAX_WATERING_DURATION, CONF_MAX_WATERING_VOLUME,
 _LOGGER = logging.getLogger(__name__)
 
 
+def _validated_gateway_ip(value: str) -> str | None:
+    """Return a normalized IPv4 gateway address, or None if invalid."""
+    candidate = value.strip()
+    try:
+        address = ipaddress.ip_address(candidate)
+    except ValueError:
+        return None
+
+    if address.version != 4:
+        return None
+    return str(address)
+
+
 @config_entries.HANDLERS.register(DOMAIN)
 class LinktapFlowHandler(config_entries.ConfigFlow):
     VERSION = 1
@@ -33,12 +47,20 @@ class LinktapFlowHandler(config_entries.ConfigFlow):
     async def async_step_user(self, user_input=None):
         """Handle a flow start."""
         _LOGGER.debug(f"Starting async_step_user of {DEFAULT_NAME}")
-        errors = None
+        errors = {}
 
         if user_input is not None:
-            await self.async_set_unique_id(secrets.token_hex(8))
-            self._abort_if_unique_id_configured()
-            return self.async_create_entry(title=DEFAULT_NAME, data=user_input)
+            gateway_ip = _validated_gateway_ip(user_input[GW_IP])
+            if gateway_ip is None:
+                errors[GW_IP] = "invalid_gateway_ip"
+            else:
+                normalized_input = dict(user_input)
+                normalized_input[GW_IP] = gateway_ip
+                await self.async_set_unique_id(secrets.token_hex(8))
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title=DEFAULT_NAME, data=normalized_input
+                )
 
         schema = vol.Schema({vol.Required(GW_IP, default=GW_IP): str})
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)

--- a/custom_components/linktap/strings.json
+++ b/custom_components/linktap/strings.json
@@ -1,4 +1,9 @@
 {
+  "config": {
+    "error": {
+      "invalid_gateway_ip": "Enter the LinkTap gateway IPv4 address only, for example 192.168.1.123. Do not include http://, a port, or /api.shtml."
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/linktap/translations/en.json
+++ b/custom_components/linktap/translations/en.json
@@ -1,4 +1,9 @@
 {
+  "config": {
+    "error": {
+      "invalid_gateway_ip": "Enter the LinkTap gateway IPv4 address only, for example 192.168.1.123. Do not include http://, a port, or /api.shtml."
+    }
+  },
   "options": {
     "step": {
       "init": {


### PR DESCRIPTION
Fixes the config-flow weakness exposed by #98.

The LinkTap gateway address was previously accepted as an unrestricted string and saved directly into the config entry. Invalid values could therefore reach aiohttp and fail later during setup with a DNS/resolver traceback.

This change:

* trims surrounding whitespace;
* validates the gateway address as IPv4;
* stores the normalized IPv4 value;
* rejects URLs, ports, paths, hostnames and IPv6;
* shows a user-friendly validation error in the config flow.

Existing config entries and runtime gateway communication are unchanged.

Pre-commit checks pass.