### PR TITLE
Update README for recent LinkTap releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,145 +1,443 @@
-A custom component for linktap tap and watering valve controllers.
+# LinkTap Local HTTP API for Home Assistant
 
-Install this Integration via the Home Assistant Community Store (HACS)
+A custom Home Assistant integration for LinkTap TapLinkers and ValveLinkers using the LinkTap gateway's **local HTTP API**.
 
-Linktap already have an MQTT implementation, but for home assistant users its support is rudimentary. They have a more advanced mode of operation via MQTT, but it involves complicated manual setup of switches and sensors.
-This custom component replaces both of those mechanisms, and uses the locally available HTTP API.
+The integration provides local control and monitoring of LinkTap devices, including LinkTap-style **Instant Watering**, device status, water/flow sensors, cumulative watering totals, water-plan pause controls, alerts, and optional Home Assistant-side watering safety limits.
 
-In short, its designed to replicate the "Instant Watering" functionality of the Linktapp app. Ie `water for x minutes`, or `until y volume is reached`.
+> [!IMPORTANT]
+> The LinkTap gateway's **Local HTTP API must be enabled** and the gateway must be reachable directly from Home Assistant on the local network.
 
-It requires just the configuration IP of your gateway. If you have more than 1 gateway, you can setup multiple instances of the integration.
+## Installation
 
-A device is created for each tap found. Multi-valve TapLinkers or ValveLinkers will get a device created for each output.
+Install the integration through **HACS** and restart Home Assistant if required.
 
+Then add it from:
 
-<b>How do I use this integration?</b>
-<p>
-Set the Watering Volume number entity and the Watering Duration number entity to your desired limits, and turn on the switch/valve. Whichever value is reached first will turn the switch/valve off. <br/>
-If you set the Watering Volume to 0, then the setting is ignored and the switch/valve will turn off when the Watering Duration is reached.
-</p>
-For each device, multiple entities are created:<br>
-binary sensors:
+**Settings → Devices & services → Add integration → Local HTTP API for LinkTap**
 
-| Binary Sensor Name       | Description  |
-|--------------------------|-------------------------------------------------------|
-| Is Linked               | Is the tap linked to the gateway?                     |
-| Has a fall alert        | Has an alert been raised due to a detected fall?      |
-| Has a cutoff alert      | Has something happened to the tap and it failed to shut off? |
-| Is leaking              | Has the tap detected a leak?                          |
-| Is clogged              | Has the tap detected it is clogged?                   |
-| Is broken               | Is the tap in an otherwise broken state?              |
-| Is Manual Mode          | Has the tap been triggered manually (via physical button)? |
-| Is Paused               | Has the tap been paused?                              |
-| Is Watering             | Is the tap currently watering?                        |
+Enter the **IPv4 address of the LinkTap gateway**, for example:
 
+```text
+192.168.1.123
+```
 
-Binary sensors also have some services registered:<br/>
-dismiss_alerts: dismiss all alerts<br/>
-dismiss_alert: dismisses a single alert. Takes an entity ID of one of the binary sensors.
+Do not enter a URL, port, path, hostname or IPv6 address, for example:
 
-Other than the alerts, the binary sensors are information about a tap, and are not controlled by the integration.
+```text
+http://192.168.1.123
+192.168.1.123:80
+192.168.1.123/api.shtml
+gateway-hostname.local
+```
 
-sensors:
+Since v0.8.4, the config flow now validates and normalises the gateway IPv4 address before saving it.
 
-| Sensor Name           | Description  |
-|-----------------------|-----------------------------|
-| Signal               | Strength of the signal between the tap and gateway |
-| Battery              | Battery level of the tap device |
-| Total Duration       | Watering duration of the current watering job. Should match the number entity, converted to seconds. |
-| Remain Duration      | Remaining watering duration, of the current watering job|
-| Watering Time Total  | Cumulative total watering time in seconds across all sessions (`TOTAL_INCREASING`). Suitable for use with the HA `utility_meter` helper. Persisted across restarts. |
-| Speed                | Water flow speed |
-| Volume               | Water volume used for the current watering job. Resets to 0 at the start of each new session. |
-| Volume Limit         | The volume limit set on the current watering job. Should match the number entity if set. |
-| Volume Total         | Cumulative total water volume across all sessions (`TOTAL_INCREASING`). Suitable for use with the HA `utility_meter` helper and energy dashboard. Persisted across restarts. |
-| Failsafe Duration    | The failsafe duration set for the tap - This is not configurable via this integration. |
-| Plan Mode            | Current watering plan mode. A numerical identifier. |
-| Plan Mode String     | A translation of the plan mode into the terms matching the app |
-| Plan SN              | Serial number of the watering plan. A numerical identifier. |
+If you have more than one LinkTap gateway, add the integration once for each gateway.
 
-number:
+## What the integration creates
 
-- Watering Duration (Defaults to 15 minutes)
-- Watering Volume (Defaults to 0)
-- Pause Duration (Defaults to 24 hours, min 1, max 96)
+A Home Assistant **device** is created for each LinkTap output discovered through the gateway.
 
-Note: The volume unit is pulled from the gateway. It can either be in L or Gal.
+For multi-valve TapLinkers or ValveLinkers, a separate Home Assistant device is created for each output.
 
-These control the watering time, volume, and pause duration when the switch for a tap is turned on by Home Assistant (ignored if ANY OTHER mechanism is used to start watering, i.e. the manual button, the mobile app, or MQTT).
-The water will turn off when either the Watering Duration or Watering Volume is reached (whichever comes first), unless the Watering Volume is set to 0, in which case it is ignored and only Watering Duration is considered.
+The integration creates:
 
-## Services
+- a main **switch** for watering;
+- a matching **valve** entity;
+- a **Pause Water Plan** switch;
+- watering duration, watering volume and pause-duration **number** entities;
+- status and alert **binary sensors**;
+- water, flow, duration, plan and diagnostic **sensors**.
+
+The main switch and valve are functionally equivalent for normal watering control and should remain in sync.
+
+## Instant Watering
+
+For normal Home Assistant instant watering:
+
+1. Set **Watering Duration**.
+2. Optionally set **Watering Volume**.
+3. Turn on the main LinkTap switch or open the LinkTap valve.
+
+The integration sends both limits to the LinkTap gateway. Watering **stops when the first applicable limit is reached.**
+
+### Watering Duration
+
+- Unit: **minutes**
+- Default: **15 minutes**
+- Native integration range: **0–120 minutes**
+- Step: **5 minutes**
+
+### Watering Volume
+
+- Unit: the volume unit configured on the LinkTap gateway, normally **L** or **Gal**
+- Default: **0**
+- Native integration range: **0–2000**
+- Step: **10**
+
+A Watering Volume value of `0` means **no volume cutoff**. In that case watering is controlled by duration only.
+
+> [!NOTE]
+> These Home Assistant duration/volume helpers are used for watering started through the integration's normal switch/valve control path. Watering started from the LinkTap app, the physical device button, MQTT, or another external mechanism is controlled by LinkTap itself and does not use these Home Assistant helper values.
+
+## Optional instant-watering safety limits
+
+Since **v0.8.3**, optional per-device Home Assistant safety ceilings can be configured for instant watering.
+
+Open:
+
+**Settings → Devices & services → LinkTap → Configure**
+
+For each LinkTap device you may independently set:
+
+- **Maximum watering duration:** 5–120 minutes
+- **Maximum watering volume:** 10–2000 in the gateway's configured volume unit
+
+Either limit may be left unset.
+
+These are **Home Assistant-side safety controls only**. They do not modify the LinkTap gateway, firmware, watering plans or native LinkTap limits.
+
+When configured, the selected maximum:
+
+- reduces the maximum allowed value of the corresponding Home Assistant number entity;
+- clamps a restored/default helper value into the permitted range;
+- is enforced again immediately before the normal switch watering command is sent;
+- is exposed as a state attribute for diagnostic visibility.
+
+`0` retains its existing special meaning for Watering Volume: **no volume cutoff**.
+
+> [!CAUTION]
+> The `valve.start_watering` entity service accepts its own duration in seconds and currently sends that request directly to the LinkTap API. It does not use the Watering Duration / Watering Volume number helpers, so do not assume the optional helper safety ceilings apply to that service call.
+
+## Water-plan pause controls
+
+LinkTap's pause function pauses the **Watering Plan**. It is not a conventional pause/resume control for a watering session that is currently running.
+
+The relevant entities are:
+
+- **Pause Water Plan**
+- **Pause Duration Water Plan**
+
+### Pause Duration Water Plan
+
+- Unit: **hours**
+- Default: **24 hours**
+- Range: **1–240 hours**
+- Step: **1 hour**
+
+Turning **Pause Water Plan** on pauses the LinkTap watering plan for the configured number of hours.
+
+Turning it off sends an unpause request.
+
+### Repeated-pause protection
+
+Since **v0.8.2**, the integration protects against a LinkTap local-API behaviour where sending another positive pause request while a plan is already paused can deactivate the underlying watering plan even though the gateway reports a successful response.
+
+Before sending a positive pause request, the integration refreshes gateway state and rejects another positive pause when `is_paused` is already true. Unpause while already unpaused is treated as an idempotent no-op.
+
+Because no documented safe LinkTap local-API operation is currently known for replacing or extending an already-active pause, the integration deliberately **does not change the expiry time of an existing pause**.
+
+If you need a different pause duration, unpause first and then apply a new pause.
+
+## Entity naming and renaming
+
+Since **v0.8.0**, internal relationships between LinkTap entities are resolved through Home Assistant's **Entity Registry and stable unique IDs**, rather than by reconstructing entity IDs from the LinkTap device name.
+
+This fixes a long-standing failure mode where newer Home Assistant entity-ID formats, recreated entities, area/device naming, or user-renamed entity IDs could cause the integration to miss the Watering Duration/Volume helper and silently fall back to the default duration.
+
+You may now rename LinkTap entity IDs in Home Assistant without breaking the integration's internal relationships.
+
+Existing entity IDs and unique IDs were intentionally preserved during this change, so upgrading does not force an entity migration.
+
+Example IDs for newly created/recreated entities may look like:
+
+```text
+switch.linktap_g2s01
+valve.linktap_g2s01
+switch.linktap_g2s01_pause
+number.linktap_g2s01_watering_duration
+number.linktap_g2s01_watering_volume
+number.linktap_g2s01_pause_duration
+sensor.linktap_g2s01_battery
+sensor.linktap_g2s01_signal
+```
+
+These are examples only; Home Assistant controls generated entity IDs.
+
+## Binary sensors
+
+| Binary sensor | Description |
+|---|---|
+| **Is Linked** | Whether the TapLinker is linked to the gateway |
+| **Has a Fall Alert** | Fall alert reported by the device |
+| **Has a Cutoff Alert** | Water-cutoff / failed-shutoff alert |
+| **Is Leaking** | Leak condition reported by the device |
+| **Is Clogged** | Clogged condition reported by the device |
+| **Is Broken** | Other broken/fault condition reported by the device |
+| **Is Manual Mode** | Device has been triggered manually (if device supports this)|
+| **Is Paused** | LinkTap reports the water plan as paused |
+| **Is Watering** | Device is currently watering |
+
+Since v0.8.0, the fault-oriented entities — fall, cutoff, leaking, clogged and broken — are categorised as Home Assistant **diagnostic** entities. Operational states remain normal device entities.
+
+## Sensors
+
+| Sensor | Description |
+|---|---|
+| **Signal** | Signal strength between the LinkTap device and gateway |
+| **Battery** | Device battery level |
+| **Total Duration** | Current LinkTap watering-job duration, reported in seconds |
+| **Remain Duration** | Remaining duration for the current watering job, in seconds |
+| **Watering Time Total** | Home Assistant-maintained cumulative watering time |
+| **Speed** | Current water flow rate |
+| **Volume** | Water volume reported for the current watering session |
+| **Volume Limit** | Current LinkTap volume limit |
+| **Volume Total** | Home Assistant-maintained cumulative water volume |
+| **Failsafe Duration** | LinkTap failsafe duration reported by the gateway, in seconds; currently read-only |
+| **Plan Mode** | Numeric LinkTap watering-plan mode |
+| **Plan Mode String** | Human-readable translation of the plan mode |
+| **Plan SN** | LinkTap watering-plan serial number |
+
+### Remain Duration
+
+Since v0.8.0, **Remain Duration** is normalised to `0` when watering has stopped.
+
+Some LinkTap responses retain a stale final non-zero remaining-duration value after watering ends. The integration therefore reports the gateway value while watering or paused, and `0` otherwise.
+
+## Water flow and Home Assistant statistics
+
+Since **v0.8.0**, the **Speed** sensor exposes Home Assistant's proper `volume_flow_rate` device class and `measurement` state class, using canonical units:
+
+- `L/min`
+- `gal/min`
+
+This now allows the sensor to participate correctly in Home Assistant statistics and compatible water/energy dashboard features.
+
+## Volume and watering totals
+
+### Volume
+
+`Volume` is the LinkTap gateway's raw/current-session water-volume value and is expected to reset when a new watering session begins.
+
+### Volume Total
+
+`Volume Total` is maintained by this Home Assistant integration because the local API does not provide the same cumulative total directly.
+
+It is:
+
+- persistent across Home Assistant restarts;
+- `state_class: total_increasing`;
+- suitable for Home Assistant long-term statistics;
+- suitable for `utility_meter` helpers;
+- suitable as a cumulative water source where Home Assistant accepts a water `total_increasing` sensor.
+
+The integration compensates for the gateway retaining the previous session's raw `volume` after watering finishes so that a Home Assistant restart does not count the same completed session again.
+
+### Protection against corrupt raw volume readings
+
+Since **v0.8.1**, `Volume Total` includes defensive protection against persistent corruption from grossly implausible raw volume samples.
+
+Before a raw sample can affect the persistent accumulator, the integration rejects:
+
+- non-numeric values;
+- non-finite values such as `NaN` or infinity;
+- negative values;
+- grossly implausible session-volume values.
+
+Where LinkTap reports a non-zero `volume_limit`, that is also used as a stronger contextual plausibility bound with generous tolerance.
+
+Rejected values are **dropped rather than clamped**, so they do not replace the last known-good accumulator sample. A warning is logged when a sample is rejected.
+
+This is a defensive Home Assistant safeguard. It does **not** claim to fix the underlying LinkTap telemetry source if the gateway/firmware/API itself emits a bad value.
+
+### Watering Time Total
+
+`Watering Time Total` is maintained by Home Assistant, persists across restarts, reports cumulative watering time in seconds and uses `state_class: total_increasing`.
+
+## Number entities
+
+| Number entity | Default | Range | Unit | Purpose |
+|---|---:|---:|---|---|
+| **Watering Duration** | 15 | 0–120 | min | Requested instant-watering duration |
+| **Watering Volume** | 0 | 0–2000 | L or Gal | Optional volume cutoff; `0` disables it |
+| **Pause Duration Water Plan** | 24 | 1–240 | h | Duration used when pausing the water plan |
+
+Optional per-device safety limits reduce the effective maximum of Watering Duration and/or Watering Volume.
+
+## Switch and valve
+
+Each LinkTap output has both a main **switch** and a **valve** entity.
+
+For normal operation:
+
+- switch on / valve open → start instant watering using the configured Home Assistant duration/volume values;
+- switch off / valve close → stop watering.
+
+Since v0.8.0, the valve resolves its backing switch through the Entity Registry and stable unique ID, so user-renamed entity IDs are supported.
+
+## Entity services
 
 ### `switch.pause`
 
-Pauses a tap for a specified number of hours.
+Pause or unpause a LinkTap watering plan through a LinkTap switch entity.
 
-**Fields:**
-
-- `entity_id` (required): The switch entity to pause (e.g. `switch.linktap_fake_tap_1`).
-- `hours` (optional, default: 1): Number of hours to pause the tap. If not specified, defaults to 1. If set to 0, unpauses the tap.
+| Field | Required | Description |
+|---|---|---|
+| `entity_id` | yes | LinkTap switch entity |
+| `hours` | no | Pause duration in hours; default `1`; `0` unpauses |
 
 ### `valve.pause_valve`
 
-Pauses a tap (valve) for a specified number of hours.
+Pause or unpause through a LinkTap valve entity.
 
-**Fields:**
-
-- `entity_id` (required): The valve entity to pause (e.g. `valve.linktap_fake_tap_1`).
-- `hours` (optional, default: 1): Number of hours to pause the tap. If not specified, defaults to 1. If set to 0, unpauses the tap.
+| Field | Required | Description |
+|---|---|---|
+| `entity_id` | yes | LinkTap valve entity |
+| `hours` | no | Pause duration in hours; default `1`; `0` unpauses |
 
 ### `valve.start_watering`
 
-Starts watering for a specified number of seconds.
+Start watering through a LinkTap valve entity for an explicit duration in seconds.
 
-**Fields:**
+| Field | Required | Description |
+|---|---|---|
+| `entity_id` | yes | LinkTap valve entity |
+| `seconds` | no | Watering duration in seconds; registered default `9000` |
 
-- `entity_id` (required): The valve entity to start watering (e.g. `valve.linktap_fake_tap_1`).
-- `seconds` (optional, default: 9000): Number of seconds to water. If not specified, defaults to 9000.
+This service is **separate from the normal Watering Duration/Watering Volume** helper path.
 
-### Pause Switch
+### Alert dismissal
 
-A special switch entity is created for each tap, named like `switch.pause_<tap_name>`. This switch allows you to pause or unpause a tap directly from the Home Assistant UI.
+The binary-sensor platform also exposes entity services for dismissing one alert or all applicable alerts.
 
-- Turning the pause switch **on** will pause the tap for the number of hours set in the corresponding "Pause Duration" number entity (defaults to 24 hours).
-- Turning the pause switch **off** will immediately unpause the tap.
-- The state of the pause switch reflects whether the tap is currently paused.
+## Watering plans and scheduling
 
-This is useful for quickly pausing watering without needing to call a service or automation.
+The integration can report LinkTap plan information and can **pause/unpause the existing water plan**, but it does not currently provide Home Assistant controls for creating or editing LinkTap watering schedules.
 
-switch:<br/>
-The tap controller itself. The switch has a number of attributes. In general these can be ignored, as they have matching sensors and binary_sensors, but are helpful in debugging.
+Use the LinkTap app/web interface to manage schedules.
 
-There are 3 additional attributes set by the integration itself.
+## Multiple gateways
 
-| Attribute Name           | Description  |
-|-----------------------|-----------------------------|
-| Duration Entity   | The entity the integration is using to control duration |
-| Default time | Is the time being sent set to the default? This will be true if either the number entity has never been changed, OR if the number enttiy cannot be found (eg because its been renamed -- dont do this!) |
-| Watering by Volume | Has a volume value been sent to the api when the switch/value was turned on |
+Multiple LinkTap gateways are supported.
 
-valve:<br/>
-A wrapper for the switch -- a valve for each tap
+Each gateway must:
 
-Using the switch and the valve are functionally equivalent, and the entities should always remain in sync.
+- have the Local HTTP API enabled;
+- be reachable directly by Home Assistant;
+- be added as a separate integration config entry using its IPv4 address.
 
+## Device naming changes from LinkTap
 
-As yet there is no support for controlling scheduling. The API does have support for this, but unless there is demand for it, this is likely more clunky to manage in Home Assistant than the native app.
+When a TapLinker or ValveLinker is newly added or renamed in LinkTap, there can be a delay before the new name appears in the gateway's local API.
 
+If Home Assistant initially discovers a generic name such as `TapLinker`, it waits for the gateway to update and then reload the integration.
 
-<h1>FAQ</h1>
-<b>Why don't my volume or speed values update? They always show 0.</b></br >
-Chances are you have a G1 device. The G1 devices do not have an inbuilt flow meter. To my knowledge there is no way to retrofit one within the linktap ecosystem.<br />
-https://www.link-tap.com/#!/faq/en/What-is-the-difference-between-the-G1S-and-G2S-water-timers<br /><br />
+Current versions resolve internal relationships by stable unique ID, so renaming Home Assistant entity IDs no longer breaks watering controls.
 
+## G1 devices and flow measurement
 
-<b>Why do my taps always water for 15 mins, rather than the value defined by the duration number entity?</b><br />
-This is likely due to a mapping issue with the integration. Each switch has an attribute called `duration_entity`. This should match the entity created for duration. If not, please lodge an issue.<br />
-There is also an attribute called `Default Time`. If the duration entity matches, and has been changed from the default, this should be set to `false`. If not, again please lodge an issue. <br />
-This can also occur if you have renamed entities, as it uses some fuzzy logic name matching in order to get the duration. If you have renamed entities in HA, delete the integration, change the names as desired in the Linktap app, and re-add the integration again. <br />
+If Volume or Speed always remains zero, check the LinkTap hardware model.
 
-<b>I added a new taplinker or valvelinker to my gateway, and changed the names of them in the app. Why are they called TapLinker 1 and TapLinker 2 in Home Assistant?</b><br />
-There can be a slight delay of up to 30 moinutes between devices being renamed on the mobile app and those changes being sycned with the local API. You can reload the integration later and the name changes should get picked up. Note that this will create all new entities, so dont setup any automations etc until the name change has come in.<br />
+Older **G1** devices do not have the integrated flow-meter capability available on models such as the G2S. The integration cannot provide flow or volume data that the hardware does not measure/report.
 
-<b>What do I do if i have more than 1 gateway?</b><br />
-If you have more than 1 gateway, ensure the local HTTP API is enabled on each one, and set them up separately via its IP address or hostname. The integration has been tested and is known to work with multiple gateways. There should be no limitation on how many gateways can be added, and in theory you should be able to add gateways that are connected to different linktap accounts, as long as they are directly accessible via HTTP.
+## Failsafe Duration
+
+The integration currently exposes LinkTap's reported **Failsafe Duration** as a read-only sensor.
+
+This is distinct from the optional Home Assistant instant-watering safety ceilings. The current integration does **not** provide a control for changing `failsafe_duration`.
+
+## Troubleshooting
+
+### Watering always uses 15 minutes
+
+Current releases resolve Watering Duration through the Entity Registry using its stable unique ID rather than guessing an entity ID.
+
+If a current release still falls back to 15 minutes:
+
+1. confirm the Watering Duration number entity exists and is available;
+2. check whether it is temporarily `unknown` or `unavailable`;
+3. reload the LinkTap integration;
+4. check Home Assistant logs;
+5. open an issue with the integration version, Home Assistant version and relevant diagnostics.
+
+Temporary invalid helper states are handled safely and cause the normal fallback rather than a numeric-conversion error.
+
+### Gateway address rejected during setup
+
+Enter only the gateway's IPv4 address, for example:
+
+```text
+192.168.1.123
+```
+
+Do not include a URL scheme, hostname, port or API path.
+
+### Volume Total looks incorrect
+
+Compare:
+
+- the raw LinkTap `Volume` for the completed session;
+- the increase in `Volume Total`;
+- the LinkTap app/cloud value separately.
+
+`Volume Total` accumulates the volume reported by the **local API**. The LinkTap app/cloud may present a different value, beyond the scope of this integration.
+
+Current releases also contain restart double-count protection and protection against grossly implausible raw-volume spikes.
+
+### Repeated pause is rejected
+
+This is intentional. A second positive LinkTap water-plan pause request has been observed to deactivate the underlying watering plan despite a successful gateway response, so the integration blocks it.
+
+## Recent changes
+
+### v0.8.4
+
+- Validate and normalise the LinkTap gateway IPv4 address during config flow.
+- Reject URLs, ports, paths, hostnames and IPv6 with a user-friendly error.
+
+### v0.8.3
+
+- Add optional per-device Home Assistant instant-watering safety ceilings.
+- Independently configure maximum duration and/or maximum volume.
+- Apply limits to the Home Assistant number controls and enforce them again at the normal switch command boundary.
+
+### v0.8.2
+
+- Protect against destructive repeated water-plan pause requests.
+- Refresh state before mutation and verify the resulting state.
+- Treat unpause while already unpaused as a no-op.
+
+### v0.8.1
+
+- Protect persistent `Volume Total` from grossly implausible raw-volume spikes.
+- Reject invalid/non-finite/negative samples before they can affect the accumulator.
+- Preserve restart double-count protection.
+
+### v0.8.0
+
+- Resolve sibling LinkTap entities through stable unique IDs and the Home Assistant Entity Registry.
+- Support renamed/recreated/current-format Home Assistant entity IDs.
+- Modernise device-relative entity naming while preserving existing unique IDs.
+- Add correct flow-rate metadata and statistics support.
+- Handle unavailable/unknown number helpers safely.
+- Reset stale Remaining Duration to zero when watering has stopped.
+- Categorise LinkTap fault indicators as diagnostic entities.
+- Rename pause controls to **Pause Water Plan** and **Pause Duration Water Plan**.
+
+## Reporting issues
+
+When reporting an issue, please include:
+
+- integration version;
+- Home Assistant version;
+- LinkTap gateway/device model;
+- whether the action originated from Home Assistant, the LinkTap app, MQTT or the physical device;
+- relevant logs;
+- raw/current entity values involved;
+- clear reproduction steps.
+
+For volume-related issues, include both the raw session `Volume` and the change in `Volume Total`.
+
+---
+
+This integration uses LinkTap's local HTTP API and is an independent Home Assistant community integration.


### PR DESCRIPTION
## Summary

_Hi Mate - I had a go at this, see what you think and feel free to reject, change, or otherwise its an attempt to update the readme to reflect recent updates etc.._

Comprehensively updated the README to match the current LinkTap integration through **v0.8.4**.

The existing documentation had become outdated following several recent releases and still described behaviour that is no longer correct.

### Updated documentation includes

- current installation and IPv4 gateway configuration requirements;
- entity/device creation and modern Home Assistant entity naming;
- renamed/recreated entity-ID support introduced in v0.8.0;
- instant watering duration and volume behaviour;
- optional per-device Home Assistant watering safety limits added in v0.8.3;
- clarification that `valve.start_watering` uses a separate direct-duration path;
- `Pause Water Plan` / `Pause Duration Water Plan` semantics;
- repeated-pause protection introduced in v0.8.2;
- current sensor and binary-sensor descriptions;
- Home Assistant flow-rate statistics support;
- `Volume Total` persistence, restart handling and v0.8.1 corruption protection;
- current pause-duration range;
- read-only `Failsafe Duration` behaviour;
- multiple-gateway and device-renaming guidance;
- revised troubleshooting guidance;
- a concise recent-changes summary covering v0.8.0 through v0.8.4.

The obsolete warning that renaming LinkTap entities can break watering-duration lookup has been removed, as current versions resolve internal relationships through stable unique IDs and Home Assistant's Entity Registry.

Documentation only; no integration behaviour is changed.